### PR TITLE
Tables

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -73,9 +73,6 @@ const calicodb::Options options {
     // WAL segments will look like "/location/calicodb_wal_#", where # is the segment ID.
     .wal_prefix = "/location/calicodb_wal_",
     
-    // The database instance will write info log messages at the specified log level, to the object
-    // passed in the "info_log" member.
-    .log_level = calicodb::LogLevel::TRACE,
     .info_log = nullptr,
     
     // This can be used to inject a custom storage implementation. (see the DynamicMemory class in
@@ -85,7 +82,7 @@ const calicodb::Options options {
 
 // Create or open a database at "/tmp/cats".
 calicodb::DB *db;
-const calicodb::Status s = calicodb::DB::open("/tmp/cats", options, &db);
+const calicodb::Status s = calicodb::DB::open(options, "/tmp/cats", &db);
 
 // Handle failure. s.to_string() provides a string representation of the status.
 if (!s.is_ok()) {
@@ -226,7 +223,7 @@ delete db;
 ### Destroying a database
 
 ```C++
-if (const auto s = calicodb::DB::destroy("/tmp/cats", options); s.is_ok()) {
+if (const auto s = calicodb::DB::destroy(options, "/tmp/cats"); s.is_ok()) {
     // Database has been destroyed.
 } else if (s.is_not_found()) {
     // The database does not exist.

--- a/include/calicodb/db.h
+++ b/include/calicodb/db.h
@@ -25,9 +25,9 @@ struct Options {
 class DB
 {
 public:
-    [[nodiscard]] static auto open(const Slice &path, const Options &options, DB **db) -> Status;
-    [[nodiscard]] static auto repair(const Slice &path, const Options &options) -> Status;
-    [[nodiscard]] static auto destroy(const Slice &path, const Options &options) -> Status;
+    [[nodiscard]] static auto open(const Options &options, const Slice &filename, DB **db) -> Status;
+    [[nodiscard]] static auto repair(const Options &options, const Slice &filename) -> Status;
+    [[nodiscard]] static auto destroy(const Options &options, const Slice &filename) -> Status;
 
     virtual ~DB() = default;
     [[nodiscard]] virtual auto get_property(const Slice &name, std::string &out) const -> bool = 0;

--- a/include/calicodb/db.h
+++ b/include/calicodb/db.h
@@ -1,26 +1,19 @@
 #ifndef CALICODB_DB_H
 #define CALICODB_DB_H
 
-#include "slice.h"
 #include <string>
 
 namespace calicodb
 {
 
 class Cursor;
-class InfoLogger;
-class Status;
 class Env;
-
-struct Options {
-    std::size_t page_size {0x2000};
-    std::size_t cache_size {};
-    Slice wal_prefix;
-    InfoLogger *info_log {};
-    Env *env {};
-    bool create_if_missing {true};
-    bool error_if_exists {};
-};
+class InfoLogger;
+class Slice;
+class Status;
+class Table;
+struct Options;
+struct TableOptions;
 
 class DB
 {
@@ -31,13 +24,10 @@ public:
 
     virtual ~DB() = default;
     [[nodiscard]] virtual auto get_property(const Slice &name, std::string &out) const -> bool = 0;
-    [[nodiscard]] virtual auto new_cursor() const -> Cursor * = 0;
+    [[nodiscard]] virtual auto new_table(const TableOptions &options, const Slice &name, Table **table) -> Status = 0;
     [[nodiscard]] virtual auto status() const -> Status = 0;
     [[nodiscard]] virtual auto vacuum() -> Status = 0;
     [[nodiscard]] virtual auto commit() -> Status = 0;
-    [[nodiscard]] virtual auto get(const Slice &key, std::string &value) const -> Status = 0;
-    [[nodiscard]] virtual auto put(const Slice &key, const Slice &value) -> Status = 0;
-    [[nodiscard]] virtual auto erase(const Slice &key) -> Status = 0;
 };
 
 } // namespace calicodb

--- a/include/calicodb/options.h
+++ b/include/calicodb/options.h
@@ -1,0 +1,28 @@
+#ifndef CALICODB_OPTIONS_H
+#define CALICODB_OPTIONS_H
+
+#include "slice.h"
+
+namespace calicodb {
+
+class Env;
+class InfoLogger;
+
+struct Options {
+    std::size_t page_size {0x2000};
+    std::size_t cache_size {};
+    Slice wal_prefix;
+    InfoLogger *info_log {};
+    Env *env {};
+    bool create_if_missing {true};
+    bool error_if_exists {};
+};
+
+struct TableOptions {
+    bool create_if_missing {true};
+    bool error_if_exists {};
+};
+
+} // namespace calicodb
+
+#endif // CALICODB_OPTIONS_H

--- a/include/calicodb/table.h
+++ b/include/calicodb/table.h
@@ -1,0 +1,26 @@
+#ifndef CALICODB_TABLE_H
+#define CALICODB_TABLE_H
+
+#include <string>
+
+namespace calicodb
+{
+
+class Cursor;
+class DB;
+class Slice;
+class Status;
+
+class Table
+{
+public:
+    virtual ~Table() = default;
+    [[nodiscard]] virtual auto new_cursor() const -> Cursor * = 0;
+    [[nodiscard]] virtual auto get(const Slice &key, std::string &value) const -> Status = 0;
+    [[nodiscard]] virtual auto put(const Slice &key, const Slice &value) -> Status = 0;
+    [[nodiscard]] virtual auto erase(const Slice &key) -> Status = 0;
+};
+
+} // namespace calicodb
+
+#endif // CALICODB_TABLE_H

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -6,10 +6,10 @@
 namespace calicodb
 {
 
-auto DB::open(const Slice &path, const Options &options, DB **db) -> Status
+auto DB::open(const Options &options, const Slice &filename, DB **db) -> Status
 {
     auto *ptr = new DBImpl;
-    auto s = ptr->open(path, options);
+    auto s = ptr->open(options, filename);
     if (!s.is_ok()) {
         delete ptr;
         return s;
@@ -19,14 +19,14 @@ auto DB::open(const Slice &path, const Options &options, DB **db) -> Status
     return Status::ok();
 }
 
-auto DB::repair(const Slice &path, const Options &options) -> Status
+auto DB::repair(const Options &options, const Slice &filename) -> Status
 {
-    return DBImpl::repair(path.to_string(), options);
+    return DBImpl::repair(options, filename.to_string());
 }
 
-auto DB::destroy(const Slice &path, const Options &options) -> Status
+auto DB::destroy(const Options &options, const Slice &filename) -> Status
 {
-    return DBImpl::destroy(path.to_string(), options);
+    return DBImpl::destroy(options, filename.to_string());
 }
 
 } // namespace calicodb

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -26,9 +26,9 @@ public:
     DBImpl() = default;
     ~DBImpl() override;
 
-    [[nodiscard]] static auto destroy(const std::string &path, const Options &options) -> Status;
-    [[nodiscard]] static auto repair(const std::string &path, const Options &options) -> Status;
-    [[nodiscard]] auto open(const Slice &path, const Options &options) -> Status;
+    [[nodiscard]] static auto destroy(const Options &options, const std::string &filename) -> Status;
+    [[nodiscard]] static auto repair(const Options &options, const std::string &filename) -> Status;
+    [[nodiscard]] auto open(const Options &options, const Slice &filename) -> Status;
 
     [[nodiscard]] auto new_cursor() const -> Cursor * override;
     [[nodiscard]] auto get_property(const Slice &name, std::string &out) const -> bool override;

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -252,7 +252,11 @@ auto Pager::watch_page(Page &page, PageCache::Entry &entry, int important) -> vo
             next_lsn, page.id(), image, *m_scratch));
 
         if (s.is_ok()) {
-            s = m_wal->cleanup(m_recovery_lsn);
+            auto limit = m_recovery_lsn;
+            if (limit > *m_commit_lsn) {
+                limit = *m_commit_lsn;
+            }
+            s = m_wal->cleanup(limit);
         }
         if (!s.is_ok()) {
             SET_STATUS(s);

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -1,0 +1,6 @@
+
+#include "table_impl.h"
+
+namespace calicodb {
+
+} // namespace calicodb

--- a/src/table_impl.cpp
+++ b/src/table_impl.cpp
@@ -1,0 +1,6 @@
+
+#include "table_impl.h"
+
+namespace calicodb {
+
+} // namespace calicodb

--- a/src/table_impl.h
+++ b/src/table_impl.h
@@ -1,0 +1,27 @@
+#ifndef CALICODB_TABLE_IMPL_H
+#define CALICODB_TABLE_IMPL_H
+
+#include "calicodb/table.h"
+#include "types.h"
+
+namespace calicodb {
+
+class BPlusTree;
+
+class TableImpl: public Table
+{
+public:
+    ~TableImpl() override;
+    [[nodiscard]] virtual auto new_cursor() const -> Cursor * override;
+    [[nodiscard]] virtual auto get(const Slice &key, std::string &value) const -> Status override;
+    [[nodiscard]] virtual auto put(const Slice &key, const Slice &value) -> Status override;
+    [[nodiscard]] virtual auto erase(const Slice &key) -> Status override;
+
+private:
+    BPlusTree *m_tree {};
+    Id m_root;
+};
+
+} // namespace calicodb
+
+#endif // CALICODB_TABLE_IMPL_H

--- a/test/fuzzers/fuzzer.cpp
+++ b/test/fuzzers/fuzzer.cpp
@@ -9,7 +9,7 @@ DbFuzzer::DbFuzzer(std::string path, Options *options)
     if (options != nullptr) {
         m_options = *options;
     }
-    CHECK_OK(DB::open(m_path, m_options, &m_db));
+    CHECK_OK(DB::open(m_options, m_path, &m_db));
 }
 
 DbFuzzer::~DbFuzzer()
@@ -18,7 +18,7 @@ DbFuzzer::~DbFuzzer()
 
     delete m_db;
 
-    CHECK_OK(DB::destroy(m_path, m_options));
+    CHECK_OK(DB::destroy(m_options, m_path));
 }
 
 auto DbFuzzer::reopen() -> Status
@@ -26,7 +26,7 @@ auto DbFuzzer::reopen() -> Status
     delete m_db;
     m_db = nullptr;
 
-    auto s = DB::open(m_path, m_options, &m_db);
+    auto s = DB::open(m_options, m_path, &m_db);
     if (s.is_ok()) {
         tools::validate_db(*m_db);
     }

--- a/test/unit_tests/test_recovery.cpp
+++ b/test/unit_tests/test_recovery.cpp
@@ -51,7 +51,7 @@ public:
             opts.env = env.get();
         }
         tail.resize(wal_block_size(opts.page_size));
-        return DB::open(db_prefix, opts, &db);
+        return DB::open(opts, db_prefix, &db);
     }
 
     auto open(Options *options = nullptr) -> void
@@ -229,7 +229,7 @@ TEST_F(RecoveryTests, SanityCheck)
         }
         close();
 
-        ASSERT_OK(DB::destroy(db_prefix, db_options));
+        ASSERT_OK(DB::destroy(db_options, db_prefix));
     }
 }
 


### PR DESCRIPTION
Using this pull request to work on adding table support. This one will likely be difficult... Here's what I'm thinking (based on what SQLite does):

+ Each table gets its own dedicated tree, rooted at some page
+ The tree rooted at the first page is called the "root tree"
+ The root tree stores (name, root) pairs, indicating where each child tree is rooted
+ We need a special case for vacuum, to swap a tree root page with a freelist page
+ The DB always keeps the root tree open. It keeps the other open trees in memory, and each open table gets a pointer to its tree
+ All reads and writes go through the Table object
+ Commit will be per-table
+ The database commit LSN tracks the oldest table commit LSN