### PR TITLE
Don't read the root page at the start of each transaction

### DIFF
--- a/src/pager.h
+++ b/src/pager.h
@@ -153,6 +153,7 @@ private:
     BusyHandler *const m_busy;
 
     U32 m_page_count = 0;
+    bool m_refresh = false;
 };
 
 // The first pointer map page is always on page 2, right after the root page.

--- a/test/test_concurrency.cpp
+++ b/test/test_concurrency.cpp
@@ -185,7 +185,10 @@ protected:
     {
     }
 
-    ~ConcurrencyTests() override = default;
+    ~ConcurrencyTests() override
+    {
+        delete m_env;
+    }
 
     struct Connection;
     using Operation = std::function<Status(Connection &, Barrier *)>;

--- a/test/test_crashes.cpp
+++ b/test/test_crashes.cpp
@@ -181,7 +181,10 @@ protected:
     {
     }
 
-    ~TestCrashes() override = default;
+    ~TestCrashes() override
+    {
+        delete m_env;
+    }
 
     static constexpr std::size_t kNumRecords = 512;
     static constexpr std::size_t kNumIterations = 3;

--- a/test/test_db.cpp
+++ b/test/test_db.cpp
@@ -834,6 +834,8 @@ TEST(DestructionTests, DeletesWalAndShm)
     ASSERT_FALSE(options.env->file_exists("./test"));
     ASSERT_FALSE(options.env->file_exists("./test-wal"));
     ASSERT_FALSE(options.env->file_exists("./test-shm"));
+
+    delete options.env;
 }
 
 class DBOpenTests : public DBTests


### PR DESCRIPTION
Only read the root if (a) another connection wrote to the database in-between transactions, or (b) this connection encountered an error. (b) is probably more conservative than necessary, but that case should be relatively infrequent anyway. This speeds up starting transactions.