### PR TITLE
Use `fcntl(fd, F_FULLFSYNC)` instead of `fsync()` where available (OSX only)

### DIFF
--- a/src/schema.h
+++ b/src/schema.h
@@ -17,58 +17,13 @@ class CursorImpl;
 class Pager;
 class Tree;
 
-class SchemaCursor : public Cursor
-{
-    mutable Status m_status;
-    std::string m_key;
-    std::string m_value;
-    CursorImpl *m_impl;
-
-    auto move_to_impl() -> void;
-
-public:
-    explicit SchemaCursor(Tree &tree);
-    ~SchemaCursor() override;
-
-    [[nodiscard]] auto is_valid() const -> bool override
-    {
-        return m_status.is_ok() && !m_key.empty();
-    }
-
-    [[nodiscard]] auto status() const -> Status override
-    {
-        return m_status;
-    }
-
-    [[nodiscard]] auto key() const -> Slice override
-    {
-        CALICODB_EXPECT_TRUE(is_valid());
-        return m_key;
-    }
-
-    [[nodiscard]] auto value() const -> Slice override
-    {
-        CALICODB_EXPECT_TRUE(is_valid());
-        return m_value;
-    }
-
-    auto seek(const Slice &key) -> void override;
-    auto seek_first() -> void override;
-    auto seek_last() -> void override;
-    auto next() -> void override;
-    auto previous() -> void override;
-};
-
 // Representation of the database schema
 class Schema final
 {
 public:
     explicit Schema(Pager &pager, const Status &status, char *scratch);
 
-    [[nodiscard]] auto new_cursor() -> Cursor *
-    {
-        return new SchemaCursor(*m_map);
-    }
+    [[nodiscard]] auto new_cursor() -> Cursor *;
 
     auto close() -> void;
     auto create_bucket(const BucketOptions &options, const Slice &name, Bucket *b_out) -> Status;

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -478,10 +478,14 @@ class CursorTests
       public testing::TestWithParam<U32>
 {
 protected:
-    ~CursorTests() override = default;
+    ~CursorTests() override
+    {
+        delete m_schema;
+    }
     auto SetUp() -> void override
     {
         open();
+        m_schema = new Schema(*m_pager, m_status, m_scratch.data());
         add_initial_records(*this);
     }
 
@@ -491,11 +495,12 @@ protected:
             case 0:
                 return std::make_unique<CursorImpl>(*m_tree, nullptr);
             case 1:
-                return std::make_unique<SchemaCursor>(*m_tree);
+                return std::unique_ptr<Cursor>(m_schema->new_cursor());
         }
         return nullptr;
     }
 
+    Schema *m_schema = nullptr;
     RandomGenerator random;
 };
 


### PR DESCRIPTION
If this ends up being too slow, we could have an option to opt-out and use `fsync()`. Durability should be the default, however. The problem is that OSX's `fsync()` doesn't guarantee that the device's volatile write cache has been flushed before returning. `fcntl(fd, F_FULLFSYNC)` is provided for that purpose. Also, hide `SchemaCursor` in `schema.cpp`.