### PR TITLE
Expose a consistency check routine

### DIFF
--- a/include/calicodb/options.h
+++ b/include/calicodb/options.h
@@ -85,6 +85,11 @@ struct Options final {
         kLockNormal,    // Allow concurrent access
         kLockExclusive, // Exclude other connections
     } lock_mode = kLockNormal;
+
+    enum IntegrityCheck {
+        kCheckOff,  // No integrity checking
+        kCheckFull, // Check all buckets before DB::open() returns
+    } integrity_check = kCheckOff;
 };
 
 // Options to control the behavior of a WAL connection (passed to Wal::open())

--- a/src/cursor_impl.h
+++ b/src/cursor_impl.h
@@ -36,6 +36,11 @@ public:
     auto next() -> void override;
     auto previous() -> void override;
 
+    auto check_integrity() const -> Status
+    {
+        return m_c.m_tree->check_integrity();
+    }
+
     auto TEST_tree_cursor() -> TreeCursor &;
     auto TEST_check_state() const -> void;
 };

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -35,6 +35,8 @@ public:
     auto new_tx(const WriteOptions &, Tx *&tx) -> Status override;
     auto checkpoint(CheckpointMode mode, CheckpointInfo *info_out) -> Status override;
 
+    auto check_integrity() -> Status;
+
     [[nodiscard]] auto TEST_pager() const -> Pager &;
 
 private:

--- a/src/internal.h
+++ b/src/internal.h
@@ -39,7 +39,7 @@ namespace calicodb
 inline auto debug_delay_impl(Env &env) -> void
 {
     if (env.rand() % 250 == 0) {
-        env.sleep(env.rand() % 100);
+        env.sleep(env.rand() % 1'000);
     }
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -183,12 +183,12 @@ struct Node final {
 
     [[nodiscard]] auto defrag() -> int;
     [[nodiscard]] auto alloc(uint32_t index, uint32_t size) -> int;
-    [[nodiscard]] auto write(uint32_t index, const Cell &cell) -> int;
+    [[nodiscard]] auto insert(uint32_t index, const Cell &cell) -> int;
     [[nodiscard]] auto read(uint32_t index, Cell &cell_out) const -> int;
     auto erase(uint32_t index, uint32_t cell_size) -> int;
 
-    [[nodiscard]] auto check_state() const -> int;
-    [[nodiscard]] auto assert_state() const -> bool;
+    [[nodiscard]] auto check_integrity() const -> Status;
+    [[nodiscard]] auto assert_integrity() const -> bool;
 };
 
 } // namespace calicodb

--- a/src/pager.cpp
+++ b/src/pager.cpp
@@ -35,6 +35,7 @@ auto Pager::set_page_size(uint32_t value) -> Status
         return Status::no_memory();
     }
     m_page_size = value;
+    log(m_log, "database page size is set to %u", value);
     return Status::ok();
 }
 

--- a/src/pager.h
+++ b/src/pager.h
@@ -119,6 +119,11 @@ public:
         return m_scratch.ptr();
     }
 
+    auto logger() const -> Logger *
+    {
+        return m_log;
+    }
+
     auto set_status(const Status &error) const -> void;
 
     auto TEST_wal() const -> const Wal *

--- a/src/tree.h
+++ b/src/tree.h
@@ -110,6 +110,8 @@ public:
         return m_root_id;
     }
 
+    auto check_integrity() -> Status;
+
     auto print_structure(String &repr_out) -> Status;
     auto print_nodes(String &repr_out) -> Status;
     auto TEST_validate() -> void;


### PR DESCRIPTION
Return a Status from the Node and Tree validation methods that describes the specific corruption encountered. Add an option to Options to perform an integrity check before DB::open() returns