### PR TITLE
Add option for buckets with duplicate records

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup
         run: >-
           cmake -S "${{ github.workspace }}" -B "${{ env.BUILD_DIR }}"
-          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCALICODB_CI=On
           -DCALICODB_BuildFuzzers=On -DCALICODB_FuzzerStandalone=On
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(CALICODB_Install "Install the CMake targets during the install step" ${MA
 option(CALICODB_WithASan "Build with ASan" Off)
 option(CALICODB_WithUBSan "Build with UBSan" Off)
 option(CALICODB_WithTSan "Build with TSan" Off)
+option(CALICODB_CI "Must be set if this is a CI build" Off)
 
 set(CALICODB_OPTIONS "")
 set(CALICODB_WARNINGS "")

--- a/include/calicodb/options.h
+++ b/include/calicodb/options.h
@@ -8,6 +8,10 @@
 #include <cstddef>
 #include <cstdint>
 
+#ifndef CALICODB_MAX_ALLOCATION
+#define CALICODB_MAX_ALLOCATION 2'000'000'000U
+#endif // CALICODB_MAX_ALLOCATION
+
 #ifndef CALICODB_DEFAULT_PAGE_SIZE
 #define CALICODB_DEFAULT_PAGE_SIZE 4'096U
 #endif // CALICODB_DEFAULT_PAGE_SIZE
@@ -112,6 +116,11 @@ struct WriteOptions {
 // Options for controlling the behavior of Tx::create_bucket()
 struct BucketOptions final {
     bool error_if_exists = false;
+
+    // If true, the library will ensure that all records in this bucket have unique keys.
+    // Otherwise, no uniqueness constraints are enforced. This means that multiple records
+    // within the same bucket may have the same key and value.
+    bool unique = true;
 };
 
 class BusyHandler

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -477,6 +477,9 @@ auto Node::write_child_id(uint32_t idx, Id child_id) -> void
 
 auto Node::read(uint32_t index, Cell &cell_out) const -> int
 {
+    if (index >= NodeHdr::get_cell_count(hdr())) {
+        return -1;
+    }
     const auto offset = get_ivec_slot(*this, index);
     if (offset < NodeHdr::get_cell_start(hdr())) {
         // NOTE: parser() checks the upper boundary.
@@ -594,8 +597,7 @@ auto Node::check_integrity() const -> Status
             }
             const Slice left_local(left_cell.key, minval(left_cell.key_size, left_cell.local_pl_size));
             const Slice right_local(right_cell.key, minval(right_cell.key_size, right_cell.local_pl_size));
-            const auto right_has_ovfl = right_cell.key_size > right_cell.local_pl_size;
-            if (right_local < left_local || (left_local == right_local && !right_has_ovfl)) {
+            if (right_local < left_local) {
                 return CORRUPTED_NODE("local keys for cells %u and %u are out of order", i, i + 1);
             }
         }

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -12,7 +12,9 @@ namespace calicodb
 namespace
 {
 
-constexpr size_t kMaxRootEntryLen = kVarintMaxLength;
+constexpr size_t kMinRootEntryLen = 2;
+constexpr size_t kMaxRootEntryLen = 1 + kVarintMaxLength;
+constexpr char kUniqueFlag = '\xFF';
 
 auto no_bucket(const Slice &name) -> Status
 {
@@ -102,7 +104,7 @@ Schema::Schema(Pager &pager, const Status &status, Stats &stat)
       m_pager(&pager),
       m_scratch(pager.scratch()),
       m_stat(&stat),
-      m_map(pager, stat, pager.scratch(), Id::root(), String()),
+      m_map(pager, stat, pager.scratch(), Id::root(), String(), true),
       m_internal(m_map),
       m_exposed(m_map),
       m_trees{"", &m_map, nullptr, nullptr},
@@ -132,9 +134,9 @@ auto Schema::corrupted_root_id() -> Status
     return s;
 }
 
-auto Schema::open_cursor(const Slice &name, Id root_id, Cursor *&c_out) -> Status
+auto Schema::open_cursor(const Slice &name, const RootInfo &info, Cursor *&c_out) -> Status
 {
-    if (auto *tree = construct_or_reference_tree(name, root_id)) {
+    if (auto *tree = construct_or_reference_tree(name, info)) {
         c_out = new (std::nothrow) CursorImpl(*tree);
     }
     return c_out ? Status::ok() : Status::no_memory();
@@ -144,23 +146,24 @@ auto Schema::create_bucket(const BucketOptions &options, const Slice &name, Curs
 {
     CALICODB_EXPECT_GT(m_pager->page_count(), 0);
 
-    Id root_id;
+    RootInfo info;
     auto [_, c] = unpack_cursor(m_internal);
     m_internal.find(name);
     auto s = m_internal.status();
     if (m_internal.is_valid()) {
         CALICODB_EXPECT_TRUE(s.is_ok());
-        if (!decode_and_check_root_id(m_internal.value(), root_id)) {
+        if (!decode_and_check_root_info(m_internal.value(), info)) {
             s = corrupted_root_id();
         } else if (options.error_if_exists) {
             s = Status::invalid_argument("bucket already exists");
         }
     } else if (s.is_ok()) {
         use_tree(&m_map);
-        s = m_map.create(root_id);
+        s = m_map.create(info.root_id);
         if (s.is_ok()) {
             char buf[kMaxRootEntryLen];
-            const auto len = encode_root_id(root_id, buf);
+            info.unique = options.unique;
+            const auto len = encode_root_info(info, buf);
             // On success, this call will leave c on the schema record of the bucket that we need to
             // open a cursor on below. It may invalidate `name`, so m_cursor.key() is used instead.
             // The 2 should be equivalent.
@@ -169,7 +172,7 @@ auto Schema::create_bucket(const BucketOptions &options, const Slice &name, Curs
     }
 
     if (s.is_ok() && c_out) {
-        s = open_cursor(m_internal.key(), root_id, *c_out);
+        s = open_cursor(m_internal.key(), info, *c_out);
     }
     return s;
 }
@@ -182,36 +185,42 @@ auto Schema::open_bucket(const Slice &name, Cursor *&c_out) -> Status
     m_internal.find(name);
     auto s = m_internal.status();
 
-    Id root_id;
+    RootInfo info;
     if (!m_internal.is_valid()) {
         return s.is_ok() ? no_bucket(name) : s;
-    } else if (!decode_and_check_root_id(m_internal.value(), root_id)) {
+    } else if (!decode_and_check_root_info(m_internal.value(), info)) {
         return corrupted_root_id();
     }
-    return open_cursor(m_internal.key(), root_id, c_out);
+    return open_cursor(m_internal.key(), info, c_out);
 }
 
-auto Schema::decode_root_id(const Slice &data, Id &out) -> bool
+auto Schema::decode_root_info(const Slice &data, RootInfo &info_out) -> bool
 {
+    if (data.size() < kMinRootEntryLen) {
+        return false;
+    }
+    info_out.unique = data[0] == kUniqueFlag;
+    if (!info_out.unique && data[0]) {
+        return false; // Invalid "unique flag"
+    }
     uint32_t num;
-    if (decode_varint(data.data(), data.data() + data.size(), num)) {
-        out.value = static_cast<uint32_t>(num);
+    if (decode_varint(data.data() + 1, data.data() + data.size(), num)) {
+        info_out.root_id.value = num;
         return true;
     }
     return false;
 }
 
-auto Schema::decode_and_check_root_id(const Slice &data, Id &out) -> bool
+auto Schema::decode_and_check_root_info(const Slice &data, RootInfo &info_out) -> bool
 {
-    if (!decode_root_id(data, out) || out.value > m_pager->page_count()) {
-        return false;
-    }
-    return true;
+    return decode_root_info(data, info_out) &&
+           info_out.root_id.value <= m_pager->page_count();
 }
 
-auto Schema::encode_root_id(Id id, char *root_id_out) -> size_t
+auto Schema::encode_root_info(const RootInfo &info, char *root_id_out) -> size_t
 {
-    const auto *end = encode_varint(root_id_out, id.value);
+    root_id_out[0] = info.unique ? kUniqueFlag : '\0';
+    const auto *end = encode_varint(root_id_out + 1, info.root_id.value);
     return static_cast<size_t>(end - root_id_out);
 }
 
@@ -232,19 +241,19 @@ auto Schema::find_open_tree(const Slice &name) -> Tree *
     return target;
 }
 
-auto Schema::construct_or_reference_tree(const Slice &name, Id root_id) -> Tree *
+auto Schema::construct_or_reference_tree(const Slice &name, const RootInfo &info) -> Tree *
 {
     if (auto *already_open = find_open_tree(name)) {
         return already_open;
     }
 
     String name_str;
-    if (!root_id.is_root() && append_strings(name_str, name)) {
+    if (!info.root_id.is_root() && append_strings(name_str, name)) {
         return nullptr;
     }
 
-    auto *tree = Mem::new_object<Tree>(*m_pager, *m_stat, m_scratch,
-                                       root_id, move(name_str));
+    auto *tree = Mem::new_object<Tree>(*m_pager, *m_stat, m_scratch, info.root_id,
+                                       move(name_str), info.unique);
     if (tree) {
         IntrusiveList::add_tail(tree->list_entry, m_trees);
     }
@@ -279,11 +288,11 @@ auto Schema::drop_bucket(const Slice &name) -> Status
     CALICODB_EXPECT_TRUE(s.is_ok());
     use_tree(&m_map);
 
-    Id root_id;
-    if (!decode_and_check_root_id(m_internal.value(), root_id)) {
+    RootInfo info;
+    if (!decode_and_check_root_info(m_internal.value(), info)) {
         return corrupted_root_id();
     }
-    ObjectPtr<Tree> drop(construct_or_reference_tree(m_internal.key(), root_id));
+    ObjectPtr<Tree> drop(construct_or_reference_tree(m_internal.key(), info));
     if (!drop) {
         return Status::no_memory();
     }
@@ -309,13 +318,13 @@ auto Schema::drop_bucket(const Slice &name) -> Status
         m_internal.seek_first();
         s = m_internal.status();
         while (m_internal.is_valid()) {
-            Id found_id;
-            if (!decode_and_check_root_id(m_internal.value(), found_id)) {
+            if (!decode_and_check_root_info(m_internal.value(), info)) {
                 return corrupted_root_id();
             }
-            if (found_id == rr.before) {
+            if (info.root_id == rr.before) {
+                info.root_id = rr.after;
                 char buf[kMaxRootEntryLen];
-                const auto len = encode_root_id(rr.after, buf);
+                const auto len = encode_root_info(info, buf);
                 s = m_map.put(*c, m_internal.key(), Slice(buf, len));
                 found = true;
                 break;

--- a/src/schema.h
+++ b/src/schema.h
@@ -44,16 +44,20 @@ public:
 
     auto vacuum() -> Status;
 
-    [[nodiscard]] static auto decode_root_id(const Slice &data, Id &out) -> bool;
-    [[nodiscard]] static auto encode_root_id(Id id, char *root_id_out) -> size_t;
+    struct RootInfo {
+        Id root_id;
+        bool unique;
+    };
+    [[nodiscard]] static auto decode_root_info(const Slice &data, RootInfo &info_out) -> bool;
+    [[nodiscard]] static auto encode_root_info(const RootInfo &info, char *root_id_out) -> size_t;
 
     auto TEST_validate() const -> void;
 
 private:
-    [[nodiscard]] auto decode_and_check_root_id(const Slice &data, Id &out) -> bool;
-    auto open_cursor(const Slice &name, Id root_id, Cursor *&c_out) -> Status;
+    [[nodiscard]] auto decode_and_check_root_info(const Slice &data, RootInfo &info_out) -> bool;
+    auto open_cursor(const Slice &name, const RootInfo &info, Cursor *&c_out) -> Status;
     auto corrupted_root_id() -> Status;
-    auto construct_or_reference_tree(const Slice &name, Id root_id) -> Tree *;
+    auto construct_or_reference_tree(const Slice &name, const RootInfo &info) -> Tree *;
     auto find_open_tree(const Slice &name) -> Tree *;
 
     template <class Action>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,10 @@ function(build_test NAME)
             PRIVATE calicodb_utils gtest)
     target_include_directories(${NAME}
             PRIVATE "${CALICODB_SOURCE_DIR}")
+    if(CALICODB_CI)
+        target_compile_definitions(${NAME}
+                PRIVATE CALICODB_CI=1)
+    endif()
     add_test(NAME ${NAME} COMMAND ${NAME})
 endfunction()
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -149,8 +149,7 @@ auto main(int argc, char **argv) -> int
         rc = RUN_ALL_TESTS(); // Run the registered tests.
     }
     if (rc == 0 && DebugAllocator::bytes_used() > 0) {
-        // Only report leaks if the test passed. There will likely be a leak if an
-        // ASSERT_*() fired.
+        // Only report leaks if the test passed. There may be a leak if an ASSERT_*() fired.
         TEST_LOG << "error: test leaked " << DebugAllocator::bytes_used() << " byte(s)\n";
         REPORT_DRIVER_ERROR;
         rc = -1;

--- a/test/test_bounds.cpp
+++ b/test/test_bounds.cpp
@@ -13,12 +13,15 @@
 namespace calicodb::test
 {
 
+// These tests use a lot of memory, occasionally crashing GitHub C/I runners.
+#ifndef CALICODB_CI
 class BoundaryValueTests : public testing::Test
 {
 protected:
     static constexpr size_t kMaxLen = kMaxAllocation;
     const std::string m_filename;
     char *const m_backing;
+    Options m_options;
     DB *m_db = nullptr;
 
     explicit BoundaryValueTests()
@@ -26,20 +29,17 @@ protected:
           m_backing(new char[kMaxLen + 1]())
     {
         remove_calicodb_files(m_filename);
+        m_options.auto_checkpoint = 0;
+        m_options.page_size = kMaxPageSize;
     }
 
     ~BoundaryValueTests() override
     {
         delete m_db;
         delete[] m_backing;
-    }
 
-    auto SetUp() -> void override
-    {
-        Options options;
-        options.auto_checkpoint = 0;
-        options.page_size = kMaxPageSize;
-        ASSERT_OK(DB::open(options, m_filename.c_str(), m_db));
+        // The files left by this test can be very large. Make sure to clean up.
+        remove_calicodb_files(m_filename);
     }
 
     auto payload(uint32_t size) -> Slice
@@ -57,6 +57,7 @@ protected:
         const uint32_t key_size = test_key * kMaxLen;
         const uint32_t value_size = test_value * kMaxLen;
 
+        ASSERT_OK(DB::open(m_options, m_filename.c_str(), m_db));
         ASSERT_OK(m_db->run(WriteOptions(), [=](auto &tx) {
             TestCursor c;
             auto s = test_create_and_open_bucket(tx, BucketOptions(), "bucket", c);
@@ -85,6 +86,7 @@ protected:
         const uint32_t key_size = test_key * (kMaxLen + 1);
         const uint32_t value_size = test_value * (kMaxLen + 1);
 
+        ASSERT_OK(DB::open(m_options, m_filename.c_str(), m_db));
         ASSERT_OK(m_db->run(WriteOptions(), [=](auto &tx) {
             TestCursor c;
             auto s = test_create_and_open_bucket(tx, BucketOptions(), "bucket", c);
@@ -94,10 +96,46 @@ protected:
             return Status::ok();
         }));
     }
+
+    auto test_32_bit_overflow(bool auto_checkpoint) -> void
+    {
+        // Keep the number of iterations low and the payload size high. Otherwise, the WAL grows
+        // to be way too large, since we retain many versions of each page. Still, these settings
+        // create a ~10 GB WAL.
+        static constexpr size_t kNumIterations = 5;
+        static constexpr size_t kPayloadSize = 1'000'000'000;
+        auto buffer = std::make_unique<char[]>(kPayloadSize);
+
+        // Make a database file that is larger than 4 GiB. Offsets to some locations within the
+        // file, as well as the file size itself, should overflow a 32-bit unsigned integer.
+        static_assert(kNumIterations * kPayloadSize > std::numeric_limits<uint32_t>::max());
+
+        Options options;
+        options.page_size = kMaxPageSize;
+        options.auto_checkpoint = auto_checkpoint ? options.auto_checkpoint : 0;
+        ASSERT_OK(DB::open(options, m_filename.c_str(), m_db));
+
+        for (size_t i = 0; i < kNumIterations; ++i) {
+            ASSERT_OK(m_db->run(WriteOptions(), [&buffer, i](auto &tx) {
+                TestCursor c;
+                auto s = test_create_and_open_bucket(tx, BucketOptions(), "b", c);
+                if (s.is_ok()) {
+                    put_u64(buffer.get(), i);
+                    s = tx.put(*c,
+                               Slice(buffer.get(), kPayloadSize),
+                               Slice(buffer.get(), kPayloadSize));
+                }
+                return s;
+            }));
+        }
+        ASSERT_OK(m_db->checkpoint(kCheckpointRestart, nullptr));
+        ASSERT_GT(std::filesystem::file_size(m_filename), kPayloadSize * kNumIterations);
+    }
 };
 
 TEST_F(BoundaryValueTests, BoundaryBucketName)
 {
+    ASSERT_OK(DB::open(m_options, m_filename.c_str(), m_db));
     ASSERT_OK(m_db->run(WriteOptions(), [=](auto &tx) {
         TestCursor c;
         return test_create_and_open_bucket(tx, BucketOptions(), payload(kMaxLen), c);
@@ -113,6 +151,7 @@ TEST_F(BoundaryValueTests, BoundaryBucketName)
 
 TEST_F(BoundaryValueTests, OverflowBucketName)
 {
+    ASSERT_OK(DB::open(m_options, m_filename.c_str(), m_db));
     ASSERT_NOK(m_db->run(WriteOptions(), [=](auto &tx) {
         TestCursor c;
         return test_create_and_open_bucket(tx, BucketOptions(), payload(kMaxLen + 1), c);
@@ -156,6 +195,19 @@ TEST_F(BoundaryValueTests, OverflowRecord)
     test_overflow_payload(true, true);
 }
 
+TEST_F(BoundaryValueTests, Overflow32Bits1)
+{
+    // Checkpoint the data incrementally.
+    test_32_bit_overflow(true);
+}
+
+TEST_F(BoundaryValueTests, Overflow32Bits2)
+{
+    // Checkpoint all the data at once.
+    test_32_bit_overflow(false);
+}
+#endif // CALICODB_CI
+
 class StressTests : public testing::Test
 {
 protected:
@@ -174,41 +226,6 @@ protected:
 
         // The files left by this test can be very large. Make sure to clean up.
         remove_calicodb_files(m_filename);
-    }
-
-    auto run_32_bit_overflow_test(bool auto_checkpoint) -> void
-    {
-        // Keep the number of iterations low and the payload size high. Otherwise, the WAL grows
-        // to be way too large, since we retain many versions of each page. Still, these settings
-        // create a ~10 GB WAL.
-        static constexpr size_t kNumIterations = 5;
-        static constexpr size_t kPayloadSize = 1'000'000'000;
-        auto buffer = std::make_unique<char[]>(kPayloadSize);
-
-        // Make a database file that is larger than 4 GiB. Offsets to some locations within the
-        // file, as well as the file size itself, should overflow a 32-bit unsigned integer.
-        static_assert(kNumIterations * kPayloadSize > std::numeric_limits<uint32_t>::max());
-
-        Options options;
-        options.page_size = kMaxPageSize;
-        options.auto_checkpoint = auto_checkpoint ? options.auto_checkpoint : 0;
-        ASSERT_OK(DB::open(options, m_filename.c_str(), m_db));
-
-        for (size_t i = 0; i < kNumIterations; ++i) {
-            ASSERT_OK(m_db->run(WriteOptions(), [&buffer, i](auto &tx) {
-                TestCursor c;
-                auto s = test_create_and_open_bucket(tx, BucketOptions(), "b", c);
-                if (s.is_ok()) {
-                    put_u64(buffer.get(), i);
-                    s = tx.put(*c,
-                               Slice(buffer.get(), kPayloadSize),
-                               Slice(buffer.get(), kPayloadSize));
-                }
-                return s;
-            }));
-        }
-        ASSERT_OK(m_db->checkpoint(kCheckpointRestart, nullptr));
-        ASSERT_GT(std::filesystem::file_size(m_filename), kPayloadSize * kNumIterations);
     }
 };
 
@@ -325,18 +342,6 @@ TEST_F(StressTests, LargeVacuum)
         }
         return s;
     }));
-}
-
-TEST_F(StressTests, Overflow32Bits1)
-{
-    // Checkpoint the data incrementally.
-    run_32_bit_overflow_test(true);
-}
-
-TEST_F(StressTests, Overflow32Bits2)
-{
-    // Checkpoint all the data at once.
-    run_32_bit_overflow_test(false);
 }
 
 } // namespace calicodb::test

--- a/test/test_db.cpp
+++ b/test/test_db.cpp
@@ -1144,6 +1144,53 @@ TEST_F(DBOpenTests, CustomLogger)
     ASSERT_FALSE(logger.m_str.empty());
 }
 
+TEST_F(DBOpenTests, RemembersBucketOptions)
+{
+    for (size_t i = 0; i < 2; ++i) {
+        ASSERT_OK(DB::open(Options(), m_db_name.c_str(), m_db));
+        ASSERT_OK(m_db->run(WriteOptions(), [](auto &tx) {
+            BucketOptions options;
+            options.unique = false;
+            return tx.create_bucket(options, "b", nullptr);
+        }));
+        ASSERT_OK(m_db->run(WriteOptions(), [i](auto &tx) {
+            TestCursor c;
+            auto s = test_open_bucket(tx, "b", c);
+            if (s.is_ok()) {
+                s = tx.put(*c, numeric_key(i), numeric_key(1));
+            }
+            if (s.is_ok()) {
+                s = tx.put(*c, numeric_key(i), numeric_key(0));
+            }
+            return s;
+        }));
+        delete m_db;
+    }
+    ASSERT_OK(DB::open(Options(), m_db_name.c_str(), m_db));
+    ASSERT_OK(m_db->run(ReadOptions(), [](auto &tx) {
+        TestCursor c;
+        auto s = test_open_bucket(tx, "b", c);
+        if (s.is_ok()) {
+            c->find(numeric_key(0));
+            EXPECT_TRUE(c->is_valid());
+            EXPECT_EQ(c->value(), numeric_key(0));
+            c->next();
+            EXPECT_TRUE(c->is_valid());
+            EXPECT_EQ(c->value(), numeric_key(1));
+
+            c->find(numeric_key(1));
+            EXPECT_TRUE(c->is_valid());
+            EXPECT_EQ(c->value(), numeric_key(0));
+            c->next();
+            EXPECT_TRUE(c->is_valid());
+            EXPECT_EQ(c->value(), numeric_key(1));
+        }
+        return s;
+    }));
+    delete m_db;
+    m_db = nullptr;
+}
+
 class DBPageSizeTests : public DBOpenTests
 {
 public:

--- a/utils/debug.cpp
+++ b/utils/debug.cpp
@@ -124,14 +124,14 @@ auto print_database_overview(std::ostream &os, Pager &pager) -> void
 namespace
 {
 
-constexpr auto kMaxLimit = SIZE_MAX - kMaxAllocation;
+constexpr uint64_t kMaxLimit = SIZE_MAX - kMaxAllocation;
 using DebugHeader = uint64_t;
 
 struct {
     DebugAllocator::Hook hook = nullptr;
     void *hook_arg = nullptr;
-    size_t limit = kMaxLimit;
-    size_t bytes_used = 0;
+    uint64_t limit = kMaxLimit;
+    uint64_t bytes_used = 0;
 } s_debug;
 
 } // namespace
@@ -150,7 +150,6 @@ auto debug_malloc(size_t size) -> void *
     if (s_debug.bytes_used + alloc_size > s_debug.limit) {
         return nullptr;
     }
-
     ALLOCATION_HOOK;
 
     auto *ptr = static_cast<DebugHeader *>(


### PR DESCRIPTION
Changes tree pivot invariants for such buckets. L < p <= R is changed to L <= p <= R, where L and R are the keys in the left and right children of pivot key p, respectively.