### PR TITLE
Simplify the API and make schema cursor record values human-readable

### DIFF
--- a/doc/doc.md
+++ b/doc/doc.md
@@ -154,14 +154,14 @@ if (!s.is_ok()) {
 ```
 
 ### Readonly transactions
-Readonly transactions are typically run using `DB::run(ReadOptions(), fn)`, where `fn` is a callback that reads from the database.
+Readonly transactions are typically run using `DB::view(fn)`, where `fn` is a callback that reads from the database.
 
 ```C++
 #include "calicodb/db.h"
 #include "calicodb/tx.h"
 
 const char *bucket_name = "all_kittens"; // Lambda captures are supported.
-s = db->run(calicodb::ReadOptions(), [bucket_name](const calicodb::Tx &tx) {
+s = db->view([bucket_name](const calicodb::Tx &tx) {
     // Open buckets (see #buckets) and read some data. The `tx` object is managed 
     // by the database. DB::view() will forward the status returned by this callable.
     return calicodb::Status::ok();
@@ -169,7 +169,7 @@ s = db->run(calicodb::ReadOptions(), [bucket_name](const calicodb::Tx &tx) {
 ```
 
 ### Read-write transactions
-Read-write transactions can be run using `DB::run(WriteOptions(), fn)`, where `fn` is a callable that modifies the database.
+Read-write transactions can be run using `DB::update(fn)`, where `fn` is a callable that modifies the database.
 If an error is encountered during a read-write transaction, the transaction status (queried with `Tx::status()`) may be set.
 If this happens, the transaction object, and any buckets created from it, will return immediately with this same error whenever a read/write method is called.
 The only possible course-of-action in this case is to return from `fn` and let the database clean up.
@@ -178,12 +178,12 @@ The only possible course-of-action in this case is to return from `fn` and let t
 #include "calicodb/db.h"
 #include "calicodb/tx.h"
 
-s = db->run(calicodb::WriteOptions(), [](calicodb::Tx &tx) {
+s = db->update([](calicodb::Tx &tx) {
     // Read and/or write some records. If this callable returns an OK status,
-    // `tx::commit()` is called on `tx` and the resulting status returned.
+    // Tx::commit() is called on `tx` and the resulting status returned.
     // Otherwise, the transaction is rolled back and the original non-OK 
     // status is forwarded to the caller (rollback itself cannot fail). Note 
-    // that calling tx::commit() early does not invalidate the transaction 
+    // that calling Tx::commit() early does not invalidate the transaction 
     // handle. This allows one to perform multiple batches of writes per 
     // DB::run().
     return calicodb::Status::ok();
@@ -201,7 +201,7 @@ The caller is responsible for `delete`ing the `Tx` handle when it is no longer n
 calicodb::Tx *reader;
 
 // Start a readonly transaction.
-s = db->new_tx(calicodb::ReadOptions(), reader);
+s = db->new_reader(reader);
 if (!s.is_ok()) {
 }
 
@@ -216,7 +216,7 @@ calicodb::Tx *writer;
 
 // Start a read-write transaction. The handle resulting from this call can be
 // used to modify the database contents.
-s = db->new_tx(calicodb::WriteOptions(), writer);
+s = db->new_writer(writer);
 if (!s.is_ok()) {
 }
 

--- a/fuzzers/db_bucket_fuzzer.cpp
+++ b/fuzzers/db_bucket_fuzzer.cpp
@@ -65,7 +65,7 @@ public:
 
         reopen_db();
 
-        const auto s = m_db->run(WriteOptions(), [&stream, &db = *m_db](auto &tx) {
+        const auto s = m_db->update([&stream, &db = *m_db](auto &tx) {
             std::unique_ptr<Cursor> cursors[kMaxBuckets];
             std::string str;
             std::string str2;

--- a/fuzzers/db_format_fuzzer.cpp
+++ b/fuzzers/db_format_fuzzer.cpp
@@ -60,7 +60,7 @@ public:
         auto s = DB::open(m_options, kFilename, db);
 
         if (s.is_ok()) {
-            s = db->run(WriteOptions(), [](auto &tx) {
+            s = db->update([](auto &tx) {
                 TestCursor c1;
                 TestCursor c2;
                 auto s = test_open_bucket(tx, "b1", c1);

--- a/fuzzers/db_model_fuzzer.cpp
+++ b/fuzzers/db_model_fuzzer.cpp
@@ -34,7 +34,7 @@ class Fuzzer
         delete m_c;
         delete m_tx;
         m_c = nullptr;
-        CHECK_OK(m_db->new_tx(WriteOptions(), m_tx));
+        CHECK_OK(m_db->new_writer(m_tx));
         reopen_bucket();
     }
 

--- a/include/calicodb/db.h
+++ b/include/calicodb/db.h
@@ -63,14 +63,14 @@ public:
     // Forwards the Status returned by the callable `fn`. Note that the callable accepts a const
     // Tx reference, meaning methods that modify the database state cannot be called on it.
     template <class Fn>
-    auto run(const ReadOptions &options, Fn &&fn) const -> Status;
+    auto view(Fn &&fn) const -> Status;
 
     // Run a read-write transaction
     // REQUIRES: Status Fn::operator()(Tx &) is implemented.
     // If the callable `fn` returns an OK status, the transaction is committed. Otherwise,
     // the transaction is rolled back.
     template <class Fn>
-    auto run(const WriteOptions &options, Fn &&fn) -> Status;
+    auto update(Fn &&fn) -> Status;
 
     // Start a transaction manually
     // Stores a pointer to the heap-allocated transaction object in `tx_out` and returns OK on
@@ -79,8 +79,8 @@ public:
     // it is a readonly transaction. The caller is responsible for calling delete on the Tx
     // pointer when it is no longer needed.
     // NOTE: Consider using the DB::run() API instead.
-    virtual auto new_tx(const ReadOptions &options, Tx *&tx_out) const -> Status = 0;
-    virtual auto new_tx(const WriteOptions &options, Tx *&tx_out) -> Status = 0;
+    virtual auto new_reader(Tx *&tx_out) const -> Status = 0;
+    virtual auto new_writer(Tx *&tx_out) -> Status = 0;
 };
 
 } // namespace calicodb

--- a/include/calicodb/options.h
+++ b/include/calicodb/options.h
@@ -103,16 +103,6 @@ struct WalOptions {
     Stats *stat;
 };
 
-// Options to control the behavior of a readonly transaction (passed to DB::run() and
-// DB::new_tx())
-struct ReadOptions {
-};
-
-// Options to control the behavior of a read-write transaction (passed to DB::run() and
-// DB::new_tx())
-struct WriteOptions {
-};
-
 // Options for controlling the behavior of Tx::create_bucket()
 struct BucketOptions final {
     bool error_if_exists = false;

--- a/include/calicodb/tx.h
+++ b/include/calicodb/tx.h
@@ -102,29 +102,29 @@ public:
 };
 
 template <class Fn>
-auto DB::run(const ReadOptions &options, Fn &&fn) const -> Status
+auto DB::view(Fn &&fn) const -> Status
 {
     Tx *tx;
-    auto s = new_tx(options, tx);
+    auto s = new_reader(tx);
     if (s.is_ok()) {
-        const auto *const_tx = tx;
-        s = fn(*const_tx);
+        const auto *immutable = tx;
+        s = fn(*immutable);
         delete tx;
     }
     return s;
 }
 
 template <class Fn>
-auto DB::run(const WriteOptions &options, Fn &&fn) -> Status
+auto DB::update(Fn &&fn) -> Status
 {
     Tx *tx;
-    auto s = new_tx(options, tx);
+    auto s = new_writer(tx);
     if (s.is_ok()) {
         s = fn(*tx);
         if (s.is_ok()) {
             s = tx->commit();
         }
-        // Implicit rollback of all uncommitted changes.
+        // Rollback all uncommitted changes.
         delete tx;
     }
     return s;

--- a/src/db_impl.cpp
+++ b/src/db_impl.cpp
@@ -148,7 +148,7 @@ auto DBImpl::destroy(const Options &options, const char *filename) -> Status
         // The file header is not checked until a transaction is started. Run a read
         // transaction, which will return with a non-OK status if `filename` is not a
         // valid database.
-        s = db->run(ReadOptions(), [](auto &) {
+        s = db->view([](auto &) {
             return Status::ok();
         });
         if (s.is_ok()) {
@@ -281,14 +281,14 @@ auto DBImpl::prepare_tx(bool write, TxType *&tx_out) const -> Status
     return s;
 }
 
-auto DBImpl::new_tx(const WriteOptions &, Tx *&tx_out) -> Status
-{
-    return prepare_tx(true, tx_out);
-}
-
-auto DBImpl::new_tx(const ReadOptions &, Tx *&tx_out) const -> Status
+auto DBImpl::new_reader(Tx *&tx_out) const -> Status
 {
     return prepare_tx(false, tx_out);
+}
+
+auto DBImpl::new_writer(Tx *&tx_out) -> Status
+{
+    return prepare_tx(true, tx_out);
 }
 
 auto DBImpl::TEST_pager() const -> Pager &

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -31,8 +31,8 @@ public:
     auto open(const Options &sanitized) -> Status;
 
     auto get_property(const Slice &name, void *value_out) const -> Status override;
-    auto new_tx(const ReadOptions &, Tx *&tx) const -> Status override;
-    auto new_tx(const WriteOptions &, Tx *&tx) -> Status override;
+    auto new_reader(Tx *&tx) const -> Status override;
+    auto new_writer(Tx *&tx) -> Status override;
     auto checkpoint(CheckpointMode mode, CheckpointInfo *info_out) -> Status override;
 
     auto check_integrity() -> Status;

--- a/src/schema.h
+++ b/src/schema.h
@@ -48,15 +48,12 @@ public:
         Id root_id;
         bool unique;
     };
-    [[nodiscard]] static auto decode_root_info(const Slice &data, RootInfo &info_out) -> bool;
-    [[nodiscard]] static auto encode_root_info(const RootInfo &info, char *root_id_out) -> size_t;
 
     auto TEST_validate() const -> void;
 
 private:
-    [[nodiscard]] auto decode_and_check_root_info(const Slice &data, RootInfo &info_out) -> bool;
+    auto decode_and_check_root_info(const Slice &data, RootInfo &info_out) -> Status;
     auto open_cursor(const Slice &name, const RootInfo &info, Cursor *&c_out) -> Status;
-    auto corrupted_root_id() -> Status;
     auto construct_or_reference_tree(const Slice &name, const RootInfo &info) -> Tree *;
     auto find_open_tree(const Slice &name) -> Tree *;
 

--- a/src/temp.cpp
+++ b/src/temp.cpp
@@ -28,7 +28,7 @@ public:
 
     ~TempEnv() override = default;
 
-    auto max_filename() const -> size_t override
+    [[nodiscard]] auto max_filename() const -> size_t override
     {
         return default_env().max_filename();
     }
@@ -41,7 +41,7 @@ public:
     auto new_logger(const char *, Logger *&logger_out) -> Status override
     {
         logger_out = nullptr;
-        return Status::ok();
+        return Status::not_supported();
     }
 
     auto new_file(const char *filename, OpenMode, File *&file_out) -> Status override
@@ -50,7 +50,7 @@ public:
             if (append_strings(m_filename, filename)) {
                 return Status::no_memory();
             }
-        } else if (Slice(m_filename) != Slice(filename)) {
+        } else if (Slice(m_filename) != filename) {
             // Only supports a single file: the database file. The WAL is simulated by TempWal.
             return Status::not_supported();
         }
@@ -182,9 +182,8 @@ public:
     auto rand() -> unsigned override
     {
         // This method is not called by the library. Normally, rand() is called by WalImpl to
-        // generate a salt, but this class is only ever used with TempWal. If random numbers
-        // are ever needed for in-memory databases, we should use a better PRNG.
-        return static_cast<unsigned>(::rand());
+        // generate a salt, but this class is only ever used with TempWal.
+        return 0;
     }
 
     auto sleep(unsigned micros) -> void override

--- a/test/stest_db.cpp
+++ b/test/stest_db.cpp
@@ -287,7 +287,7 @@ struct DatabaseState {
         CALICODB_EXPECT_NE(db, nullptr);
         CALICODB_EXPECT_EQ(tx, nullptr);
         ASSERT_EQ(state, kNone);
-        s = db->new_tx(ReadOptions(), tx);
+        s = db->new_reader(tx);
         if (s.is_ok()) {
             state = kReadable;
         }
@@ -298,7 +298,7 @@ struct DatabaseState {
         CALICODB_EXPECT_NE(db, nullptr);
         CALICODB_EXPECT_EQ(tx, nullptr);
         ASSERT_EQ(state, kNone);
-        s = db->new_tx(WriteOptions(), tx);
+        s = db->new_writer(tx);
         if (s.is_ok()) {
             state = kWritable;
         }

--- a/test/test_concurrency.cpp
+++ b/test/test_concurrency.cpp
@@ -307,7 +307,7 @@ protected:
         for (size_t n = 0; s.is_ok() && n < co.op_args[0]; ++n) {
             barrier_wait(barrier);
 
-            s = co.db->run(ReadOptions(), [&co, barrier](const auto &tx) {
+            s = co.db->view([&co, barrier](const auto &tx) {
                 barrier_wait(barrier);
 
                 TestCursor c;
@@ -362,7 +362,7 @@ protected:
         for (size_t n = 0; s.is_ok() && n < co.op_args[0]; ++n) {
             barrier_wait(barrier);
 
-            s = co.db->run(WriteOptions(), [&co, barrier](auto &tx) {
+            s = co.db->update([&co, barrier](auto &tx) {
                 barrier_wait(barrier);
 
                 TestCursor c;

--- a/test/test_env.cpp
+++ b/test/test_env.cpp
@@ -773,7 +773,7 @@ TEST_P(TempEnvTests, Operations)
     m_env->sleep(1);
 
     Logger *logger;
-    ASSERT_OK(m_env->new_logger("NOOP", logger));
+    ASSERT_TRUE(m_env->new_logger("NOOP", logger).is_not_supported());
     ASSERT_EQ(logger, nullptr);
 }
 

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -22,12 +22,6 @@ TEST(ConfigTests, ConfigAllocator)
     ASSERT_OK(configure(kSetAllocator, &config));
 }
 
-TEST(ConfigTests, ConfigUnrecognized)
-{
-    ASSERT_NOK(configure(static_cast<ConfigTarget>(123), nullptr));
-    ASSERT_NOK(configure(static_cast<ConfigTarget>(321), reinterpret_cast<void *>(42)));
-}
-
 class AllocTests : public testing::Test
 {
 public:

--- a/utils/model.cpp
+++ b/utils/model.cpp
@@ -31,18 +31,18 @@ auto ModelDB::check_consistency() const -> void
     reinterpret_cast<const DBImpl *>(m_db)->TEST_pager().assert_state();
 }
 
-auto ModelDB::new_tx(const WriteOptions &options, Tx *&tx_out) -> Status
+auto ModelDB::new_writer(Tx *&tx_out) -> Status
 {
-    auto s = m_db->new_tx(options, tx_out);
+    auto s = m_db->new_writer(tx_out);
     if (s.is_ok()) {
         tx_out = new ModelTx(*m_store, *tx_out);
     }
     return s;
 }
 
-auto ModelDB::new_tx(const ReadOptions &options, Tx *&tx_out) const -> Status
+auto ModelDB::new_reader(Tx *&tx_out) const -> Status
 {
-    auto s = m_db->new_tx(options, tx_out);
+    auto s = m_db->new_reader(tx_out);
     if (s.is_ok()) {
         tx_out = new ModelTx(*m_store, *tx_out);
     }

--- a/utils/model.h
+++ b/utils/model.h
@@ -78,8 +78,8 @@ public:
         return m_db->get_property(name, value_out);
     }
 
-    auto new_tx(const WriteOptions &, Tx *&tx_out) -> Status override;
-    auto new_tx(const ReadOptions &, Tx *&tx_out) const -> Status override;
+    auto new_writer(Tx *&tx_out) -> Status override;
+    auto new_reader(Tx *&tx_out) const -> Status override;
 
     auto checkpoint(CheckpointMode mode, CheckpointInfo *info_out) -> Status override
     {
@@ -178,16 +178,14 @@ public:
     auto check_record() const -> void
     {
         if (m_c->is_valid()) {
-            const auto key = m_saved
-                                 ? m_saved_key
-                                 : m_itr->first;
+            const auto key = m_saved ? m_saved_key
+                                     : m_itr->first;
             CHECK_EQ(key, to_string(m_c->key()));
 
-            std::string value;
             if constexpr (!kIsSchema) {
-                value = m_saved ? m_saved_val : m_itr->second;
+                const auto value = m_saved ? m_saved_val : m_itr->second;
+                CHECK_EQ(value, to_string(m_c->value()));
             }
-            CHECK_EQ(value, to_string(m_c->value()));
         }
     }
 


### PR DESCRIPTION
Gets rid of ReadOptions and WriteOptions, which were empty anyway.