### PR TITLE
Add tests for different types of database corruption and fix some res…

### DIFF
--- a/fuzzers/db_bucket_fuzzer.cpp
+++ b/fuzzers/db_bucket_fuzzer.cpp
@@ -23,7 +23,7 @@ class Fuzzer
     auto reopen_db() -> void
     {
         delete m_db;
-        CHECK_OK(ModelDB::open(m_options, "MemDB", m_store, m_db));
+        CHECK_OK(ModelDB::open(m_options, "/MemDB", m_store, m_db));
     }
 
 public:
@@ -207,6 +207,7 @@ public:
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     CHECK_OK(configure(kSetAllocator, DebugAllocator::config()));
+    default_env().srand(42);
     {
         FuzzedInputProvider stream(data, size);
         Fuzzer fuzzer;

--- a/fuzzers/db_format_fuzzer.cpp
+++ b/fuzzers/db_format_fuzzer.cpp
@@ -22,7 +22,7 @@ namespace calicodb
 
 class Fuzzer
 {
-    static constexpr auto *kFilename = "./MemDB";
+    static constexpr auto *kFilename = "/MemDB";
     Options m_options;
 
 public:
@@ -100,7 +100,6 @@ public:
                         while (c2->is_valid() && s.is_ok()) {
                             if (c2->is_bucket()) {
                                 s = b2->drop_bucket(c2->key());
-                                CHECK_TRUE(s == c2->status());
                             } else if (c2->key() < c2->value()) {
                                 s = b2->erase(*c2);
                                 CHECK_TRUE(s == c2->status());
@@ -130,12 +129,6 @@ public:
             }
 
             delete db;
-
-            if (s.is_corruption()) {
-#ifdef INTEGRITY_CHECK
-                CHECK_OK(s);
-#endif
-            }
         }
 
         CHECK_TRUE(
@@ -149,6 +142,7 @@ public:
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     CHECK_OK(configure(kSetAllocator, DebugAllocator::config()));
+    default_env().srand(42);
     {
         FakeEnv env;
         Fuzzer fuzzer(env);

--- a/fuzzers/db_model_fuzzer.cpp
+++ b/fuzzers/db_model_fuzzer.cpp
@@ -28,7 +28,7 @@ class Fuzzer
         m_c = nullptr;
         m_b = nullptr;
         m_tx = nullptr;
-        CHECK_OK(ModelDB::open(m_options, "InMemory", m_store, m_db));
+        CHECK_OK(ModelDB::open(m_options, "/InMemory", m_store, m_db));
         reopen_tx();
     }
 
@@ -200,6 +200,7 @@ public:
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     CHECK_OK(configure(kSetAllocator, DebugAllocator::config()));
+    default_env().srand(42);
     {
         FakeEnv env;
         Fuzzer fuzzer(env);

--- a/include/calicodb/cursor.h
+++ b/include/calicodb/cursor.h
@@ -15,6 +15,13 @@ namespace calicodb
 // Cursors are obtained by calling Bucket::new_cursor(). It should be noted that a
 // freshly-allocated cursor is not considered valid (is_valid() returns false) until
 // find() or one of the seek*() methods returns an OK status.
+// Cursors enforce certain guarantees to make working with them easier. If a cursor
+// returns true for is_valid(), then the slices returned by key() and value() will
+// not be invalidated until the cursor is moved, even if the bucket is modified by a
+// different cursor. The bucket that a cursor is open on can be closed before the
+// cursor itself. Such a cursor will be invalidated, however, calling seek*() or
+// find() is not allowed. The only thing one can do with a stranded cursor is call
+// delete on it.
 class Cursor
 {
 public:

--- a/include/calicodb/env.h
+++ b/include/calicodb/env.h
@@ -8,6 +8,7 @@
 #include "slice.h"
 #include "status.h"
 #include <cstdarg>
+#include <cstdint>
 
 namespace calicodb
 {

--- a/src/db_impl.cpp
+++ b/src/db_impl.cpp
@@ -111,7 +111,6 @@ DBImpl::DBImpl(Parameters param)
       m_auto_ckpt(param.sanitized.auto_checkpoint),
       m_db_filename(move(param.db_name)),
       m_wal_filename(move(param.wal_name)),
-      m_owns_log(param.original.info_log != param.sanitized.info_log),
       m_owns_env(param.original.env != param.sanitized.env &&
                  param.sanitized.env != &default_env())
 {
@@ -126,9 +125,6 @@ DBImpl::~DBImpl()
     }
     m_file.reset();
 
-    if (m_owns_log) {
-        delete m_log;
-    }
     if (m_owns_env) {
         delete m_env;
     }

--- a/src/db_impl.h
+++ b/src/db_impl.h
@@ -64,7 +64,6 @@ private:
     const size_t m_auto_ckpt;
     const String m_db_filename;
     const String m_wal_filename;
-    const bool m_owns_log;
     const bool m_owns_env;
 };
 

--- a/src/header.h
+++ b/src/header.h
@@ -52,52 +52,52 @@ struct FileHdr {
     };
     static_assert(kReservedOffset < kSize);
 
-    [[nodiscard]] static constexpr auto get_page_count(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_page_count(const char *root) -> uint32_t
     {
         return get_u32(root + kPageCountOffset);
     }
 
-    static constexpr auto put_page_count(char *root, uint32_t value) -> void
+    static auto put_page_count(char *root, uint32_t value) -> void
     {
         put_u32(root + kPageCountOffset, value);
     }
 
-    [[nodiscard]] static constexpr auto get_freelist_head(const char *root) -> Id
+    [[nodiscard]] static auto get_freelist_head(const char *root) -> Id
     {
         return Id(get_u32(root + kFreelistHeadOffset));
     }
 
-    static constexpr auto put_freelist_head(char *root, Id value) -> void
+    static auto put_freelist_head(char *root, Id value) -> void
     {
         put_u32(root + kFreelistHeadOffset, value.value);
     }
 
-    [[nodiscard]] static constexpr auto get_freelist_length(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_freelist_length(const char *root) -> uint32_t
     {
         return get_u32(root + kFreelistLengthOffset);
     }
 
-    static constexpr auto put_freelist_length(char *root, uint32_t value) -> void
+    static auto put_freelist_length(char *root, uint32_t value) -> void
     {
         put_u32(root + kFreelistLengthOffset, value);
     }
 
-    [[nodiscard]] static constexpr auto get_largest_root(const char *root) -> Id
+    [[nodiscard]] static auto get_largest_root(const char *root) -> Id
     {
         return Id(get_u32(root + kLargestRootOffset));
     }
 
-    static constexpr auto put_largest_root(char *root, Id value) -> void
+    static auto put_largest_root(char *root, Id value) -> void
     {
         put_u32(root + kLargestRootOffset, value.value);
     }
 
-    [[nodiscard]] static constexpr auto get_page_size(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_page_size(const char *root) -> uint32_t
     {
         return get_u16(root + kPageSizeOffset);
     }
 
-    static constexpr auto put_page_size(char *root, uint32_t value) -> void
+    static auto put_page_size(char *root, uint32_t value) -> void
     {
         put_u16(root + kPageSizeOffset, static_cast<uint16_t>(value));
     }
@@ -131,7 +131,7 @@ struct NodeHdr {
         kSize = kNextIdOffset + sizeof(uint32_t)
     };
 
-    [[nodiscard]] static constexpr auto get_type(const char *root) -> Type
+    [[nodiscard]] static auto get_type(const char *root) -> Type
     {
         switch (root[kTypeOffset]) {
             case kInternal:
@@ -142,53 +142,53 @@ struct NodeHdr {
                 return kInvalid;
         }
     }
-    static constexpr auto put_type(char *root, bool is_external) -> void
+    static auto put_type(char *root, bool is_external) -> void
     {
         root[kTypeOffset] = static_cast<char>(kInternal + is_external);
     }
 
-    [[nodiscard]] static constexpr auto get_cell_count(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_cell_count(const char *root) -> uint32_t
     {
         return get_u16(root + kCellCountOffset);
     }
-    static constexpr auto put_cell_count(char *root, uint32_t value) -> void
+    static auto put_cell_count(char *root, uint32_t value) -> void
     {
         put_u16(root + kCellCountOffset, static_cast<uint16_t>(value));
     }
 
-    [[nodiscard]] static constexpr auto get_cell_start(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_cell_start(const char *root) -> uint32_t
     {
         return get_u16(root + kCellStartOffset);
     }
-    static constexpr auto put_cell_start(char *root, uint32_t value) -> void
+    static auto put_cell_start(char *root, uint32_t value) -> void
     {
         put_u16(root + kCellStartOffset, static_cast<uint16_t>(value));
     }
 
-    [[nodiscard]] static constexpr auto get_free_start(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_free_start(const char *root) -> uint32_t
     {
         return get_u16(root + kFreeStartOffset);
     }
-    static constexpr auto put_free_start(char *root, uint32_t value) -> void
+    static auto put_free_start(char *root, uint32_t value) -> void
     {
         put_u16(root + kFreeStartOffset, static_cast<uint16_t>(value));
     }
 
-    [[nodiscard]] static constexpr auto get_frag_count(const char *root) -> uint32_t
+    [[nodiscard]] static auto get_frag_count(const char *root) -> uint32_t
     {
         // This cast prevents sign extension.
         return static_cast<uint8_t>(root[kFragCountOffset]);
     }
-    static constexpr auto put_frag_count(char *root, uint32_t value) -> void
+    static auto put_frag_count(char *root, uint32_t value) -> void
     {
         root[kFragCountOffset] = static_cast<char>(value);
     }
 
-    [[nodiscard]] static constexpr auto get_next_id(const char *root) -> Id
+    [[nodiscard]] static auto get_next_id(const char *root) -> Id
     {
         return Id(get_u32(root + kNextIdOffset));
     }
-    static constexpr auto put_next_id(char *root, Id value) -> void
+    static auto put_next_id(char *root, Id value) -> void
     {
         put_u32(root + kNextIdOffset, value.value);
     }

--- a/src/header.h
+++ b/src/header.h
@@ -52,54 +52,53 @@ struct FileHdr {
     };
     static_assert(kReservedOffset < kSize);
 
-    [[nodiscard]] static auto get_page_count(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_page_count(const char *root) -> uint32_t
     {
         return get_u32(root + kPageCountOffset);
     }
 
-    static auto put_page_count(char *root, uint32_t value) -> void
+    static constexpr auto put_page_count(char *root, uint32_t value) -> void
     {
         put_u32(root + kPageCountOffset, value);
     }
 
-    [[nodiscard]] static auto get_freelist_head(const char *root) -> Id
+    [[nodiscard]] static constexpr auto get_freelist_head(const char *root) -> Id
     {
         return Id(get_u32(root + kFreelistHeadOffset));
     }
 
-    static auto put_freelist_head(char *root, Id value) -> void
+    static constexpr auto put_freelist_head(char *root, Id value) -> void
     {
         put_u32(root + kFreelistHeadOffset, value.value);
     }
 
-    [[nodiscard]] static auto get_freelist_length(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_freelist_length(const char *root) -> uint32_t
     {
         return get_u32(root + kFreelistLengthOffset);
     }
 
-    static auto put_freelist_length(char *root, uint32_t value) -> void
+    static constexpr auto put_freelist_length(char *root, uint32_t value) -> void
     {
         put_u32(root + kFreelistLengthOffset, value);
     }
 
-    [[nodiscard]] static auto get_largest_root(const char *root) -> Id
+    [[nodiscard]] static constexpr auto get_largest_root(const char *root) -> Id
     {
         return Id(get_u32(root + kLargestRootOffset));
     }
 
-    static auto put_largest_root(char *root, Id value) -> void
+    static constexpr auto put_largest_root(char *root, Id value) -> void
     {
         put_u32(root + kLargestRootOffset, value.value);
     }
 
-    [[nodiscard]] static auto get_page_size(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_page_size(const char *root) -> uint32_t
     {
         return get_u16(root + kPageSizeOffset);
     }
 
-    static auto put_page_size(char *root, uint32_t value) -> void
+    static constexpr auto put_page_size(char *root, uint32_t value) -> void
     {
-        CALICODB_EXPECT_TRUE(check_page_size(value).is_ok());
         put_u16(root + kPageSizeOffset, static_cast<uint16_t>(value));
     }
 };
@@ -112,8 +111,9 @@ struct FileHdr {
 //     3       2     Cell area start
 //     5       2     Freelist start
 //     7       1     Fragment count
-//     8       4     Next ID
-// TODO: Only internal nodes need a "Next ID".
+//     8       4     Next ID*
+//
+// * Only external nodes have this field.
 struct NodeHdr {
     enum Type : char {
         kInvalid = 0,
@@ -131,7 +131,7 @@ struct NodeHdr {
         kSize = kNextIdOffset + sizeof(uint32_t)
     };
 
-    [[nodiscard]] static auto get_type(const char *root) -> Type
+    [[nodiscard]] static constexpr auto get_type(const char *root) -> Type
     {
         switch (root[kTypeOffset]) {
             case kInternal:
@@ -142,53 +142,53 @@ struct NodeHdr {
                 return kInvalid;
         }
     }
-    static auto put_type(char *root, bool is_external) -> void
+    static constexpr auto put_type(char *root, bool is_external) -> void
     {
         root[kTypeOffset] = static_cast<char>(kInternal + is_external);
     }
 
-    [[nodiscard]] static auto get_cell_count(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_cell_count(const char *root) -> uint32_t
     {
         return get_u16(root + kCellCountOffset);
     }
-    static auto put_cell_count(char *root, uint32_t value) -> void
+    static constexpr auto put_cell_count(char *root, uint32_t value) -> void
     {
         put_u16(root + kCellCountOffset, static_cast<uint16_t>(value));
     }
 
-    [[nodiscard]] static auto get_cell_start(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_cell_start(const char *root) -> uint32_t
     {
         return get_u16(root + kCellStartOffset);
     }
-    static auto put_cell_start(char *root, uint32_t value) -> void
+    static constexpr auto put_cell_start(char *root, uint32_t value) -> void
     {
         put_u16(root + kCellStartOffset, static_cast<uint16_t>(value));
     }
 
-    [[nodiscard]] static auto get_free_start(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_free_start(const char *root) -> uint32_t
     {
         return get_u16(root + kFreeStartOffset);
     }
-    static auto put_free_start(char *root, uint32_t value) -> void
+    static constexpr auto put_free_start(char *root, uint32_t value) -> void
     {
         put_u16(root + kFreeStartOffset, static_cast<uint16_t>(value));
     }
 
-    [[nodiscard]] static auto get_frag_count(const char *root) -> uint32_t
+    [[nodiscard]] static constexpr auto get_frag_count(const char *root) -> uint32_t
     {
         // This cast prevents sign extension.
         return static_cast<uint8_t>(root[kFragCountOffset]);
     }
-    static auto put_frag_count(char *root, uint32_t value) -> void
+    static constexpr auto put_frag_count(char *root, uint32_t value) -> void
     {
         root[kFragCountOffset] = static_cast<char>(value);
     }
 
-    [[nodiscard]] static auto get_next_id(const char *root) -> Id
+    [[nodiscard]] static constexpr auto get_next_id(const char *root) -> Id
     {
         return Id(get_u32(root + kNextIdOffset));
     }
-    static auto put_next_id(char *root, Id value) -> void
+    static constexpr auto put_next_id(char *root, Id value) -> void
     {
         put_u32(root + kNextIdOffset, value.value);
     }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -512,13 +512,13 @@ Node::Options::Options(uint32_t page_size, char *scratch)
 
 auto Node::from_existing_page(const Options &options, PageRef &page, Node &node_out) -> int
 {
-    const auto max_cell_count = MAX_CELL_COUNT(options.total_space);
     const auto hdr_offset = page_offset(page.page_id);
     const auto *hdr = page.data + hdr_offset;
     const auto type = NodeHdr::get_type(hdr);
     if (type == NodeHdr::kInvalid) {
         return -1;
     }
+    const auto max_cell_count = MAX_CELL_COUNT(options.total_space);
     const auto ncells = NodeHdr::get_cell_count(hdr);
     if (ncells > max_cell_count) {
         return -1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ endfunction()
 
 build_test(test_bounds)
 build_test(test_concurrency)
+build_test(test_corruption)
 build_test(test_crashes)
 build_test(test_db)
 build_test(test_env)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -121,6 +121,7 @@ auto main(int argc, char **argv) -> int
     using namespace calicodb;
     using namespace calicodb::test;
     ::testing::InitGoogleTest(&argc, argv);
+    default_env().srand(42);
 
 #define STR(name) #name
 #define XSTR(name) STR(name)

--- a/test/test_corruption.cpp
+++ b/test/test_corruption.cpp
@@ -1,0 +1,347 @@
+// Copyright (c) 2022, The CalicoDB Authors. All rights reserved.
+// This source code is licensed under the MIT License, which can be found in
+// LICENSE.md. See AUTHORS.md for a list of contributor names.
+
+#include "calicodb/cursor.h"
+#include "calicodb/db.h"
+#include "common.h"
+#include "fake_env.h"
+#include "header.h"
+#include "test.h"
+
+namespace calicodb::test
+{
+
+class CorruptionTests : public testing::Test
+{
+protected:
+    static constexpr size_t kN = 1'234;
+    int m_status_counters[3] = {};
+    const std::string m_filename;
+    std::string m_junk;
+    std::string m_backup;
+    FakeEnv m_env;
+    Options m_options;
+
+    explicit CorruptionTests()
+        : m_filename("/fake_database"),
+          m_junk("0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxy")
+    {
+        m_options.env = &m_env;
+        m_options.page_size = TEST_PAGE_SIZE;
+
+        while (m_junk.size() < 256) {
+            m_junk.append(m_junk);
+        }
+        m_junk.resize(256);
+    }
+
+    ~CorruptionTests() override = default;
+
+    auto SetUp() -> void override
+    {
+        DB *db;
+        ASSERT_OK(DB::open(m_options, m_filename.c_str(), db));
+        ASSERT_OK(db->update([](auto &tx) {
+            TestBucket b;
+            auto &main = tx.main_bucket();
+            EXPECT_OK(test_create_and_open_bucket(main, "b1", b));
+            for (size_t i = 0; i < kN; ++i) {
+                EXPECT_OK(b->put(numeric_key(i), numeric_key(i)));
+                EXPECT_OK(b->put("*" + numeric_key(i), numeric_key(i)));
+            }
+            for (size_t i = 0; i < kN; ++i) {
+                EXPECT_OK(b->erase("*" + numeric_key(i)));
+            }
+            return Status::ok();
+        }));
+        delete db;
+
+        m_backup = *m_env.get_file_contents(m_filename.c_str());
+    }
+
+    auto database_file() const -> std::string &
+    {
+        auto *file = m_env.get_file_contents(m_filename.c_str());
+        EXPECT_NE(file, nullptr) << "database has not been created";
+        return *file;
+    }
+
+    auto open_database() const
+    {
+        DB *db;
+        // DB::open() doesn't touch the database file (unless it needs to run a checkpoint, which
+        // is not the case here), so it will never detect corruption.
+        EXPECT_OK(DB::open(m_options, m_filename.c_str(), db));
+        return std::unique_ptr<DB>(db);
+    }
+
+    auto set_normal_contents() const -> std::string &
+    {
+        auto &file = database_file();
+        file = m_backup; // Refresh data
+        return file;
+    }
+
+    auto set_corrupted_contents(size_t iteration) const
+    {
+        auto &file = set_normal_contents();
+        const auto offset = iteration * m_junk.size();
+        if (offset + m_junk.size() > file.size()) {
+            return false;
+        }
+        std::memcpy(file.data() + offset, m_junk.data(), m_junk.size());
+        return true;
+    }
+
+    // Make sure the given status has an expected status code. Allowed status codes are
+    // kOK (corruption was not detected), kInvalidArgument (database file does not appear
+    // to be a CalicoDB database), and kCorruption (corruption was detected).
+    auto check_status(const Status &s)
+    {
+        // Only 1 of the following s.is_*() will ever be true.
+        const auto index = s.is_ok() +
+                           s.is_invalid_argument() * 2 +
+                           s.is_corruption() * 3;
+        ASSERT_GT(index, 0) << s.message();
+        ++m_status_counters[index - 1];
+    }
+
+    auto run_read_transaction(const DB &db)
+    {
+        // Scan through "b1".
+        return db.view([](const auto &tx) {
+            TestBucket b1;
+            auto s = test_open_bucket(tx, "b1", b1);
+            if (s.is_ok()) {
+                auto c = test_new_cursor(*b1);
+                c->seek_first();
+                while (c->is_valid()) {
+                    c->next();
+                }
+                s = c->status();
+            }
+            return s;
+        });
+    }
+
+    auto run_write_transaction(DB &db)
+    {
+        // Transfer records from "b1" to "b2"
+        return db.update([](auto &tx) {
+            TestBucket b1, b2;
+            auto &main = tx.main_bucket();
+            auto s = test_open_bucket(main, "b1", b1);
+            if (s.is_ok()) {
+                s = test_create_and_open_bucket(main, "b2", b2);
+            }
+            if (!s.is_ok()) {
+                return s;
+            }
+            auto c1 = test_new_cursor(*b1);
+            c1->seek_first();
+            while (s.is_ok() && c1->is_valid()) {
+                s = b2->put(c1->key(), c1->value());
+                c1->next();
+            }
+            return s;
+        });
+    }
+
+    auto test_corrupted_database()
+    {
+        auto db = open_database();
+
+        auto s = run_read_transaction(*db);
+        check_status(s);
+
+        s = run_write_transaction(*db);
+        check_status(s);
+
+        s = db->update([](auto &tx) {
+            TestBucket b1;
+            auto &main = tx.main_bucket();
+            auto s = test_open_bucket(main, "b1", b1);
+            if (!s.is_ok()) {
+                return s;
+            }
+            // Clear b1.
+            auto c1 = test_new_cursor(*b1);
+            c1->seek_first();
+            while (c1->is_valid()) {
+                s = b1->erase(*c1);
+                EXPECT_EQ(s, c1->status());
+            }
+            if (s.is_ok()) {
+                s = main.drop_bucket("b1");
+                b1.reset(); // Free b1's pages
+            }
+            if (s.is_ok()) {
+                s = tx.vacuum();
+            }
+            return s;
+        });
+        check_status(s);
+
+        s = db->view([](const auto &tx) {
+            TestBucket b2;
+            auto &main = tx.main_bucket();
+            auto s = test_open_bucket(main, "b2", b2);
+            if (!s.is_ok()) {
+                return s;
+            }
+            // Scan b2 backwards.
+            auto c2 = test_new_cursor(*b2);
+            c2->seek_last();
+            while (c2->is_valid()) {
+                c2->previous();
+            }
+            return s;
+        });
+        check_status(s);
+    }
+};
+
+TEST_F(CorruptionTests, GenericCorruption)
+{
+    for (size_t i = 0; set_corrupted_contents(i); ++i) {
+        test_corrupted_database();
+    }
+    TEST_LOG << "StatusCounters:\n"
+             << "kOK:              " << m_status_counters[0] << '\n'
+             << "kInvalidArgument: " << m_status_counters[1] << '\n'
+             << "kCorruption:      " << m_status_counters[2] << '\n';
+}
+
+TEST_F(CorruptionTests, CorruptedFormatString)
+{
+    auto &file = set_normal_contents();
+    std::strcpy(file.data(), "calicoDB format 1"); // 'C' -> 'c' at 0
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_invalid_argument()) << s.message();
+}
+
+TEST_F(CorruptionTests, IncorrectFormatVersion)
+{
+    auto &file = set_normal_contents();
+    ++file[FileHdr::kFmtVersionOffset];
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_invalid_argument()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedPageSize1)
+{
+    auto &file = set_normal_contents();
+    FileHdr::put_page_size(file.data(), kMinPageSize / 2);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedPageSize2)
+{
+    auto &file = set_normal_contents();
+    FileHdr::put_page_size(file.data(), kMaxPageSize * 2);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedPageSize3)
+{
+    auto &file = set_normal_contents();
+    FileHdr::put_page_size(file.data(), kMinPageSize + 1);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedLargestRoot)
+{
+    auto &file = set_normal_contents();
+    FileHdr::put_largest_root(file.data(), Id::null());
+
+    auto s = run_write_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedFreelistHead)
+{
+    auto &file = set_normal_contents();
+    FileHdr::put_freelist_head(file.data(), Id(1'234'567'890));
+
+    auto s = run_write_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedFreelistLength)
+{
+    auto &file = set_normal_contents();
+    const auto freelist_len = FileHdr::get_freelist_length(file.data());
+    FileHdr::put_freelist_length(file.data(), freelist_len * 2);
+
+    auto s = run_write_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedNodeType)
+{
+    auto &file = set_normal_contents();
+    file[FileHdr::kSize] = '\xFF';
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedCellCount)
+{
+    auto &file = set_normal_contents();
+    NodeHdr::put_cell_count(file.data() + FileHdr::kSize, 0xFFFF);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedCellAreaStart)
+{
+    auto &file = set_normal_contents();
+    NodeHdr::put_cell_start(file.data() + FileHdr::kSize, TEST_PAGE_SIZE + 1);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedFreelistStart)
+{
+    auto &file = set_normal_contents();
+    NodeHdr::put_free_start(file.data() + FileHdr::kSize, TEST_PAGE_SIZE + 1);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedFragmentCount)
+{
+    auto &file = set_normal_contents();
+    NodeHdr::put_frag_count(file.data() + FileHdr::kSize, 0xFF);
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+TEST_F(CorruptionTests, CorruptedNextID)
+{
+    auto &file = set_normal_contents();
+    // Page 3 is the root page of "b1", which contains many records already. It should have split
+    // already, becoming an internal node with a "next ID" field.
+    const auto page3 = file.data() + TEST_PAGE_SIZE * 2;
+    ASSERT_EQ(NodeHdr::kInternal, NodeHdr::get_type(page3));
+    NodeHdr::put_next_id(page3, Id::null());
+
+    auto s = run_read_transaction(*open_database());
+    ASSERT_TRUE(s.is_corruption()) << s.message();
+}
+
+} // namespace calicodb::test

--- a/test/test_crashes.cpp
+++ b/test/test_crashes.cpp
@@ -819,9 +819,9 @@ TEST_F(CrashTests, CursorModification_Syscall)
 TEST_F(CrashTests, CursorModification_OOM)
 {
     run_cursor_modify_test({kOOMFaults, false, false});
-//    run_cursor_modify_test({kOOMFaults, true, false});
-//    run_cursor_modify_test({kOOMFaults, false, true});
-//    run_cursor_modify_test({kOOMFaults, true, true});
+    //    run_cursor_modify_test({kOOMFaults, true, false});
+    //    run_cursor_modify_test({kOOMFaults, false, true});
+    //    run_cursor_modify_test({kOOMFaults, true, true});
 }
 
 #undef MAYBE_CRASH

--- a/test/test_env.cpp
+++ b/test/test_env.cpp
@@ -751,20 +751,28 @@ public:
 
 TEST_P(TempEnvTests, Operations)
 {
+    ASSERT_OK(m_file->resize(123));
+    uint64_t file_size;
+    ASSERT_OK(m_file->get_size(file_size));
+    ASSERT_EQ(file_size, 123);
+
     // NOOPs.
-    EXPECT_OK(m_file->file_lock(FileLockMode()));
+    m_file->shm_barrier();
+    ASSERT_OK(m_file->sync());
+    ASSERT_OK(m_file->file_lock(FileLockMode()));
     m_file->file_unlock();
 
     // Not supported.
-    EXPECT_NOK(m_file->shm_lock(0, 1, ShmLockFlag()));
+    ASSERT_NOK(m_file->shm_lock(0, 1, ShmLockFlag()));
     volatile void *ptr;
-    EXPECT_NOK(m_file->shm_map(0, false, ptr));
+    ASSERT_NOK(m_file->shm_map(0, false, ptr));
     m_file->shm_unmap(true);
 
     // File should still be accessible through the pointer returned by new_file().
-    EXPECT_TRUE(m_env->file_exists("temp"));
-    EXPECT_OK(m_env->remove_file("temp"));
-    EXPECT_FALSE(m_env->file_exists("temp"));
+    ASSERT_TRUE(m_env->file_exists("temp"));
+    ASSERT_OK(m_env->remove_file("temp"));
+    ASSERT_NOK(m_env->remove_file("temp"));
+    ASSERT_FALSE(m_env->file_exists("temp"));
 
     m_file.reset();
 

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -165,7 +165,7 @@ public:
 
     ~BlockAllocatorTests() override = default;
 
-    auto reserve_for_test(uint32_t n, bool is_external = true) -> void
+    auto reserve_for_test(uint32_t n) -> void
     {
         // Make the gap large so BlockAllocator doesn't get confused.
         NodeHdr::put_cell_start(

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -165,7 +165,7 @@ public:
 
     ~BlockAllocatorTests() override = default;
 
-    auto reserve_for_test(uint32_t n) -> void
+    auto reserve_for_test(uint32_t n, bool is_external = true) -> void
     {
         // Make the gap large so BlockAllocator doesn't get confused.
         NodeHdr::put_cell_start(

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -177,8 +177,8 @@ TEST_F(TreeTests, ConstructsAndDestructs)
 
 TEST_F(TreeTests, SearchLeaf)
 {
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "b", "", false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "d", "", false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "b", "", false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "d", "", false));
 
     m_c->find("b");
     ASSERT_TRUE(m_c->is_valid());
@@ -213,7 +213,7 @@ TEST_F(TreeTests, SearchLeaf)
 
 TEST_F(TreeTests, RecordsAreErased)
 {
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "a", make_value('1'), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "a", make_value('1'), false));
     m_c->find("a");
     ASSERT_OK(m_tree->erase(tree_cursor_cast(*m_c), false));
     m_c->find("a");
@@ -222,9 +222,9 @@ TEST_F(TreeTests, RecordsAreErased)
 
 TEST_F(TreeTests, HandlesLargePayloads)
 {
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key('1'), "1", false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "2", make_value('2', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key('3'), make_value('3', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key('1'), "1", false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "2", make_value('2', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key('3'), make_value('3', true), false));
 
     m_c->find(make_long_key('1'));
     ASSERT_TRUE(m_c->is_valid());
@@ -249,9 +249,9 @@ TEST_F(TreeTests, LongVsShortKeys)
     for (int i = 0; i < 2; ++i) {
         const auto actual_key_len = i == 0 ? 1U : TEST_PAGE_SIZE * 2 - 1;
         const auto search_key_len = TEST_PAGE_SIZE * 2 - actual_key_len;
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), std::string(actual_key_len, 'a'), make_value('1', true), false));
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), std::string(actual_key_len, 'b'), make_value('2', true), false));
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), std::string(actual_key_len, 'c'), make_value('3', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), std::string(actual_key_len, 'a'), make_value('1', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), std::string(actual_key_len, 'b'), make_value('2', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), std::string(actual_key_len, 'c'), make_value('3', true), false));
 
         m_c->seek(std::string(search_key_len, i == 0 ? 'A' : 'a'));
         ASSERT_TRUE(m_c->is_valid());
@@ -278,15 +278,15 @@ TEST_F(TreeTests, LongVsShortKeys)
 TEST_F(TreeTests, GetNonexistentKeys)
 {
     // Missing 0
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(1), make_value('1', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(1), make_value('1', true), false));
     // Missing 2
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(3), make_value('3', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(4), make_value('4', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(5), make_value('5', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(3), make_value('3', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(4), make_value('4', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(5), make_value('5', true), false));
     // Missing 6
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(7), make_value('7', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(8), make_value('8', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(9), make_value('9', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(7), make_value('7', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(8), make_value('8', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(9), make_value('9', true), false));
     // Missing 10
 
     m_c->find(make_long_key(0));
@@ -318,7 +318,7 @@ TEST_F(TreeTests, GetNonexistentKeys)
 TEST_F(TreeTests, ResolvesOverflowsOnLeftmostPosition1)
 {
     for (size_t i = 0; i < 100; ++i) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(99 - i), make_value('*'), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(99 - i), make_value('*'), false));
     }
     validate();
 }
@@ -326,7 +326,7 @@ TEST_F(TreeTests, ResolvesOverflowsOnLeftmostPosition1)
 TEST_F(TreeTests, ResolvesOverflowsOnLeftmostPosition2)
 {
     for (size_t i = 0; i < 100; ++i) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(99 - i), make_value('*', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(99 - i), make_value('*', true), false));
         validate();
     }
 }
@@ -334,7 +334,7 @@ TEST_F(TreeTests, ResolvesOverflowsOnLeftmostPosition2)
 TEST_F(TreeTests, ResolvesOverflowsOnRightmostPosition1)
 {
     for (size_t i = 0; i < 100; ++i) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(i), make_value('*'), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(i), make_value('*'), false));
     }
     validate();
 }
@@ -342,7 +342,7 @@ TEST_F(TreeTests, ResolvesOverflowsOnRightmostPosition1)
 TEST_F(TreeTests, ResolvesOverflowsOnRightmostPosition2)
 {
     for (size_t i = 0; i < 100; ++i) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(i), make_value('*', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(i), make_value('*', true), false));
     }
     validate();
 }
@@ -350,8 +350,8 @@ TEST_F(TreeTests, ResolvesOverflowsOnRightmostPosition2)
 TEST_F(TreeTests, ResolvesOverflowsOnMiddlePosition1)
 {
     for (size_t i = 0, j = 99; i < j; ++i, --j) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(i), make_value('*'), false));
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(j), make_value('*'), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(i), make_value('*'), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(j), make_value('*'), false));
     }
     validate();
 }
@@ -359,8 +359,8 @@ TEST_F(TreeTests, ResolvesOverflowsOnMiddlePosition1)
 TEST_F(TreeTests, ResolvesOverflowsOnMiddlePosition2)
 {
     for (size_t i = 0, j = 99; i < j; ++i, --j) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(i), make_value('*', true), false));
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(j), make_value('*', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(i), make_value('*', true), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(j), make_value('*', true), false));
     }
     validate();
 }
@@ -373,10 +373,10 @@ static constexpr InitFlag kInitFlagMax = 3;
 static auto init_tree(TreeTestHarness &test, InitFlag flags = kInitNormal)
 {
     for (size_t i = 0; i < kInitialRecordCount; ++i) {
-        ASSERT_OK(test.m_tree->put(tree_cursor_cast(*test.m_c),
-                                   flags & kInitLongKeys ? TreeTestHarness::make_long_key(i)
-                                                         : TreeTestHarness::make_normal_key(i),
-                                   TreeTestHarness::make_value('*', flags & kInitLongValues), false));
+        ASSERT_OK(test.m_tree->insert(tree_cursor_cast(*test.m_c),
+                                      flags & kInitLongKeys ? TreeTestHarness::make_long_key(i)
+                                                            : TreeTestHarness::make_normal_key(i),
+                                      TreeTestHarness::make_value('*', flags & kInitLongValues), false));
     }
     test.validate();
     test.m_tree->deactivate_cursors(nullptr);
@@ -453,11 +453,11 @@ TEST_F(TreeTests, SplitWithShortAndLongKeys)
     for (unsigned i = 0; i < kInitialRecordCount; ++i) {
         char key[2];
         put_u16(key, static_cast<uint16_t>(kInitialRecordCount - i - 1));
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), {key, sizeof(key)}, "v", false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), {key, sizeof(key)}, "v", false));
     }
     for (unsigned i = 0; i < kInitialRecordCount; ++i) {
         const auto key = random.Generate(TEST_PAGE_SIZE);
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), key, "v", false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), key, "v", false));
     }
     validate();
 }
@@ -465,7 +465,7 @@ TEST_F(TreeTests, SplitWithShortAndLongKeys)
 TEST_F(TreeTests, AllowsEmptyKey)
 {
     for (InitFlag flag = kInitNormal; flag <= kInitFlagMax; ++flag) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "", "value", false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "", "value", false));
         init_tree(*this, flag);
         m_c->find("");
         ASSERT_TRUE(m_c->is_valid());
@@ -478,7 +478,7 @@ TEST_F(TreeTests, AllowsEmptyKey)
 TEST_F(TreeTests, AlreadyErased1)
 {
     TreeCursor c(*m_tree);
-    ASSERT_OK(m_tree->put(c, "a", "1", false));
+    ASSERT_OK(m_tree->insert(c, "a", "1", false));
     c.read_record();
 
     // Erase normal record out from under c.
@@ -505,7 +505,7 @@ TEST_F(TreeTests, AlreadyErased2)
     char root_id[sizeof(uint32_t)];
     put_u32(root_id, 123);
     allocate_some_pages(*m_pager);
-    ASSERT_OK(m_tree->put(c, "a", Slice(root_id, sizeof(root_id)), true));
+    ASSERT_OK(m_tree->insert(c, "a", Slice(root_id, sizeof(root_id)), true));
     c.read_record();
 
     // Erase bucket record out from under c.
@@ -520,7 +520,7 @@ TEST_F(TreeTests, AlreadyErased3)
 {
     TreeCursor c(*m_tree);
     allocate_some_pages(*m_pager);
-    ASSERT_OK(m_tree->put(c, "a", "1", false));
+    ASSERT_OK(m_tree->insert(c, "a", "1", false));
     c.read_record();
 
     // Replace normal record with bucket record.
@@ -530,7 +530,7 @@ TEST_F(TreeTests, AlreadyErased3)
     ASSERT_OK(m_tree->erase(tree_cursor_cast(*m_c), false));
     char root_id[sizeof(uint32_t)];
     put_u32(root_id, 123);
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "a", Slice(root_id, sizeof(root_id)), true));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "a", Slice(root_id, sizeof(root_id)), true));
 
     ASSERT_NOK(m_tree->erase(c, false));
 }
@@ -558,7 +558,7 @@ public:
     {
         const auto key = random_chunk(overflow_keys);
         const auto val = random_chunk(overflow_values, false);
-        EXPECT_OK(m_tree->put(tree_cursor_cast(*m_c), key, val, false));
+        EXPECT_OK(m_tree->insert(tree_cursor_cast(*m_c), key, val, false));
         return {key.to_string(), val.to_string()};
     }
 
@@ -610,7 +610,7 @@ TEST_P(TreeSanityChecks, SmallRecords)
     for (size_t iteration = 0; iteration < 3; ++iteration) {
         for (size_t i = 0; i < record_count * 10; ++i) {
             const auto key = numeric_key<6>(i);
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), key, "", false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), key, "", false));
             records[key] = "";
         }
         validate();
@@ -657,7 +657,7 @@ public:
         // an overflow page.
         const auto prefix_size = m_random.Next(0, 64) + m_base_size;
         auto key = std::string(prefix_size, '0') + numeric_key(k);
-        EXPECT_OK(m_tree->put(tree_cursor_cast(*m_c), key, key, false));
+        EXPECT_OK(m_tree->insert(tree_cursor_cast(*m_c), key, key, false));
         m_keys.push_back(std::move(key));
     }
 
@@ -1006,7 +1006,7 @@ TEST_F(MultiCursorTests, CursorIsUnaffectedByModifications)
     ASSERT_EQ(cursor->key(), make_normal_key(0));
     ASSERT_EQ(cursor->value(), v0);
 
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_normal_key(0), "value", false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_normal_key(0), "value", false));
     ASSERT_EQ(cursor->key(), make_normal_key(0));
     ASSERT_EQ(cursor->value(), v0);
 }
@@ -1045,7 +1045,7 @@ TEST_F(MultiCursorTests, LotsOfCursors)
     }
 
     // Both put() and erase() cause live cursors to be saved.
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), "key", "value", false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), "key", "value", false));
     m_c->find("key");
     ASSERT_OK(m_tree->erase(tree_cursor_cast(*m_c), false));
 }
@@ -1067,9 +1067,9 @@ TEST_F(MultiCursorTests, ModifyNodeWithCursors)
     auto &c3 = *m_cursors.at(2);
     auto &c4 = *m_cursors.at(3);
 
-    ASSERT_OK(m_tree->put(tree_cursor_cast(c4), "a", make_value('1', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(c4), "b", make_value('2', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(c4), "c", make_value('3', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(c4), "a", make_value('1', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(c4), "b", make_value('2', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(c4), "c", make_value('3', true), false));
 
     c1.find("a");
     ASSERT_TRUE(c1.is_valid());
@@ -1081,9 +1081,9 @@ TEST_F(MultiCursorTests, ModifyNodeWithCursors)
     const auto key_a = make_value('a', true);
     const auto key_b = make_value('b', true);
     const auto key_c = make_value('c', true);
-    ASSERT_OK(m_tree->put(tree_cursor_cast(c4), key_a, make_value('4', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(c4), key_b, make_value('5', true), false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(c4), key_c, make_value('6', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(c4), key_a, make_value('4', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(c4), key_b, make_value('5', true), false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(c4), key_c, make_value('6', true), false));
 
     c4.find(key_a.c_str());
     ASSERT_TRUE(c4.is_valid());
@@ -1846,10 +1846,10 @@ public:
             size_t iteration = 0;
             for (size_t i = 0; i < GetParam(); ++i) {
                 for (const auto &[k, value_size] : info) {
-                    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c),
-                                          numeric_key(iteration * info.size() + k),
-                                          m_random.Generate(value_size),
-                                          false));
+                    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c),
+                                             numeric_key(iteration * info.size() + k),
+                                             m_random.Generate(value_size),
+                                             false));
                 }
                 ++iteration;
             }
@@ -1977,7 +1977,7 @@ public:
     auto test_sequential_overwrite(size_t size_step, bool forward) -> void
     {
         for (size_t i = 0; i < kInitialRecordCount; ++i) {
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(i), "", false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(i), "", false));
         }
 
         static constexpr size_t kIterations = 5;
@@ -1990,7 +1990,7 @@ public:
 
             for (size_t i = 0; m_c->is_valid(); ++i) {
                 const std::string value((iteration + 1) * size_step, '*');
-                ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), m_c->key(), value, false))
+                ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), m_c->key(), value, false))
                     << iteration << ':' << i;
 
                 if (forward) {
@@ -2020,7 +2020,7 @@ TEST_F(CursorModificationTests, QuickCheck)
     for (std::ptrdiff_t i = 0; i < 2; ++i) {
         for (const auto *key : {"BB", "CC", "AA"}) {
             const auto *value = key + i;
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), key, value, false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), key, value, false));
             tree_cursor_cast(*m_c).read_record();
             ASSERT_TRUE(m_c->is_valid());
             ASSERT_EQ(Slice(key), m_c->key());
@@ -2044,7 +2044,7 @@ TEST_F(CursorModificationTests, QuickCheck)
 TEST_F(CursorModificationTests, PayloadSlicesAreStable)
 {
     TreeCursor c(*m_tree);
-    ASSERT_OK(m_tree->put(c, "key", "value", false));
+    ASSERT_OK(m_tree->insert(c, "key", "value", false));
     c.read_record();
     ASSERT_TRUE(c.is_valid());
     const auto stable_key = reinterpret_cast<uintptr_t>(c.key().data());
@@ -2062,7 +2062,7 @@ TEST_F(CursorModificationTests, SeekAndPut)
 {
     auto num_records = kInitialRecordCount;
     for (size_t i = 0; i < num_records; ++i) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(i * 2), make_value('*'), false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(i * 2), make_value('*'), false));
     }
     for (size_t iteration = 0; iteration < 2; ++iteration) {
         auto step = num_records / 10;
@@ -2072,7 +2072,7 @@ TEST_F(CursorModificationTests, SeekAndPut)
             m_c->seek_last();
         }
         for (size_t i = 0; m_c->is_valid() && i < kInitialRecordCount; ++i) {
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), make_long_key(i * 2 + iteration), make_value('*', true), false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), make_long_key(i * 2 + iteration), make_value('*', true), false));
             ++num_records;
             for (size_t j = 0; m_c->is_valid() && j < step; ++j) {
                 if (iteration == 0) {
@@ -2136,9 +2136,9 @@ TEST_F(CursorModificationTests, SizeDiscrepancy1)
     for (size_t iteration = 0; iteration < 5; ++iteration) {
         const auto offset = kN * iteration;
         const auto first_key = numeric_key(offset) + make_long_key(0);
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), first_key, "first_value", false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), first_key, "first_value", false));
         for (size_t i = 0; i < kN; ++i) {
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(i + offset + 1), make_value('*'), false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(i + offset + 1), make_value('*'), false));
             for (size_t j = 0; j <= i; ++j) {
                 ASSERT_TRUE(m_c->is_valid());
                 m_c->previous(); // Repositions the tree cursor and reads the payload
@@ -2157,9 +2157,9 @@ TEST_F(CursorModificationTests, SizeDiscrepancy2)
     for (size_t iteration = 0; iteration < 5; ++iteration) {
         const auto offset = (iteration + 1) * kN;
         const auto last_key = numeric_key(offset - 1) + make_long_key(0);
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), last_key, "last_value", false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), last_key, "last_value", false));
         for (size_t i = 0; i < kN; ++i) {
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(offset - i - 1), make_value('*'), false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(offset - i - 1), make_value('*'), false));
             for (size_t j = 0; j <= i; ++j) {
                 ASSERT_TRUE(m_c->is_valid());
                 m_c->next(); // Repositions the tree cursor and reads the payload
@@ -2262,7 +2262,7 @@ TEST_F(CursorModificationTests, OverwriteBackward4)
 TEST_F(CursorModificationTests, OverwriteRandom)
 {
     for (size_t i = 0; i < kInitialRecordCount; ++i) {
-        ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(i), "", false));
+        ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(i), "", false));
     }
 
     static constexpr size_t kSize = 250;
@@ -2275,7 +2275,7 @@ TEST_F(CursorModificationTests, OverwriteRandom)
         }
         while (m_c->is_valid()) {
             const std::string value((iteration + 1) * kSize, '*');
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), m_c->key(), value, false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), m_c->key(), value, false));
 
             if (iteration == 0) {
                 m_c->next();
@@ -2305,7 +2305,7 @@ TEST_F(CursorModificationTests, OverwriteExactSize)
         std::string target(64U << iteration, static_cast<char>('0' + iteration));
         for (size_t i = 0; i < kInitialRecordCount; ++i) {
             put_u64(target.data(), i);
-            ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), numeric_key(i), target, false));
+            ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), numeric_key(i), target, false));
         }
         for (size_t i = 0; i < kInitialRecordCount; ++i) {
             put_u64(target.data(), i);
@@ -2549,9 +2549,9 @@ TEST_F(VacuumTests, VacuumOverflowChains)
         {'_' + make_long_key(3), make_value('c', true)},
     };
     init_tree(*this);
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), kv[0][0], kv[0][1], false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), kv[1][0], kv[1][1], false));
-    ASSERT_OK(m_tree->put(tree_cursor_cast(*m_c), kv[2][0], kv[2][1], false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), kv[0][0], kv[0][1], false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), kv[1][0], kv[1][1], false));
+    ASSERT_OK(m_tree->insert(tree_cursor_cast(*m_c), kv[2][0], kv[2][1], false));
 
     for (size_t i = 0; i < kInitialRecordCount; ++i) {
         m_c->find(make_normal_key(i));

--- a/utils/fake_env.h
+++ b/utils/fake_env.h
@@ -17,8 +17,7 @@ class FakeEnv : public Env
 {
 public:
     [[nodiscard]] virtual auto clone() const -> Env *;
-    [[nodiscard]] virtual auto get_file_contents(const char *filename) const -> std::string;
-    virtual auto put_file_contents(const char *filename, std::string contents) -> void;
+    [[nodiscard]] virtual auto get_file_contents(const char *filename) const -> std::string *;
 
     ~FakeEnv() override = default;
 


### PR DESCRIPTION
…ulting bugs

Also, make sure cursor statuses are set to the same status returned by put() and erase() overloads that take cursors, no matter what happens. This makes it easier to use these methods safely, since there is only 1 status to check to determine success or failure.