### PR TITLE
Add a system call fault injection API

### DIFF
--- a/fuzzers/db_bucket_fuzzer.cpp
+++ b/fuzzers/db_bucket_fuzzer.cpp
@@ -206,7 +206,7 @@ public:
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    CHECK_OK(configure(kSetAllocator, DebugAllocator::config()));
+    CHECK_OK(configure(kReplaceAllocator, DebugAllocator::config()));
     default_env().srand(42);
     {
         FuzzedInputProvider stream(data, size);

--- a/fuzzers/db_format_fuzzer.cpp
+++ b/fuzzers/db_format_fuzzer.cpp
@@ -141,7 +141,7 @@ public:
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    CHECK_OK(configure(kSetAllocator, DebugAllocator::config()));
+    CHECK_OK(configure(kReplaceAllocator, DebugAllocator::config()));
     default_env().srand(42);
     {
         FakeEnv env;

--- a/fuzzers/db_model_fuzzer.cpp
+++ b/fuzzers/db_model_fuzzer.cpp
@@ -199,7 +199,7 @@ public:
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    CHECK_OK(configure(kSetAllocator, DebugAllocator::config()));
+    CHECK_OK(configure(kReplaceAllocator, DebugAllocator::config()));
     default_env().srand(42);
     {
         FakeEnv env;

--- a/include/calicodb/config.h
+++ b/include/calicodb/config.h
@@ -38,18 +38,25 @@ struct AllocatorConfig {
     Free free;
 };
 
-// Specifies a target for configure(). configure() expects different variadic parameters depending on
-// the configuration target.
-enum ConfigTarget {
-    kGetAllocator, // AllocatorConfig * (valid address)
-    kSetAllocator, // AllocatorConfig *
+struct SyscallConfig {
+    const char *name;
+    void *syscall;
+};
+
+// Specifies a target for configure(). configure() expects a different argument depending on the config
+// target.                 Type                    | Details
+enum ConfigTarget {    // -------------------------|------------------------------------------------------
+    kReplaceAllocator, //  const AllocatorConfig * | Replace the general-purpose allocator
+    kRestoreAllocator, //  nullptr                 | Restore the general-purpose allocator to the default
+    kReplaceSyscall,   //  const SyscallConfig *   | Replace a system call
+    kRestoreSyscall,   //  const char *            | Restore the named syscall to its default
 };
 
 // Configure per-process options
 // This function is not safe to call from multiple threads simultaneously.
 // If `target` is recognized and the configuration option set successfully, an OK status is returned.
 // Otherwise, a non-OK status is returned with no side effects.
-auto configure(ConfigTarget target, void *value) -> Status;
+auto configure(ConfigTarget target, const void *value) -> Status;
 
 } // namespace calicodb
 

--- a/src/bufmgr.cpp
+++ b/src/bufmgr.cpp
@@ -181,6 +181,7 @@ auto Bufmgr::shrink_to_fit() -> void
 
 auto Bufmgr::assert_state() const -> bool
 {
+#ifndef NDEBUG
     // Make sure the refcounts add up to the "refsum".
     uint32_t refsum = 0;
     for (auto p = m_in_use.next_entry; p != &m_in_use; p = p->next_entry) {
@@ -207,6 +208,9 @@ auto Bufmgr::assert_state() const -> bool
         CALICODB_EXPECT_EQ(p->refs, 0);
     }
     return refsum == m_refsum;
+#else
+    return true;
+#endif // NDEBUG
 }
 
 auto Bufmgr::PageTable::allocate(size_t min_buffers) -> int

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -48,6 +48,7 @@ auto get_full_filename(Env &env, const char *filename, String &result_out) -> St
 
 auto DB::open(const Options &options, const char *filename, DB *&db) -> Status
 {
+    db = nullptr;
     DBImpl *impl = nullptr;
     auto sanitized = options;
     clip_to_range(sanitized.page_size, kMinPageSize, kMaxPageSize);

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -3,7 +3,6 @@
 // LICENSE.md. See AUTHORS.md for a list of contributor names.
 
 #include "tree.h"
-#include "cursor_impl.h"
 #include "encoding.h"
 #include "internal.h"
 #include "logging.h"
@@ -722,6 +721,7 @@ auto TreeCursor::value() const -> Slice
 
 auto TreeCursor::assert_state() const -> bool
 {
+#ifndef NDEBUG
     if (m_state == kHasRecord) {
         CALICODB_EXPECT_TRUE(has_valid_position(true));
     } else if (m_state == kSaved) {
@@ -746,6 +746,7 @@ auto TreeCursor::assert_state() const -> bool
                                m_node_path[i + 1].ref ? m_node_path[i + 1].page_id() : m_node.page_id());
         }
     }
+#endif // NDEBUG
     return true;
 }
 

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -1297,10 +1297,8 @@ auto WalImpl::recover_index() -> Status
             s = Status::no_memory();
             goto cleanup;
         }
-        compute_checksum(
-            Slice(header, kWalHdrSize - 8),
-            nullptr,
-            m_hdr.frame_cksum);
+        compute_checksum(Slice(header, kWalHdrSize - 8),
+                         nullptr, m_hdr.frame_cksum);
         if (m_hdr.frame_cksum[0] == get_u32(&header[24]) &&
             m_hdr.frame_cksum[1] == get_u32(&header[28])) {
             // Checksums match, meaning there is valid WAL data. Reconstruct the hash index from it

--- a/test/stest_db.cpp
+++ b/test/stest_db.cpp
@@ -49,23 +49,8 @@ struct DatabaseState {
     } state = kNone;
 
     static constexpr const char *kBucketNames[] = {
-        "A",
-        "B",
-        "C",
-        "D",
-        "E",
-        "F",
-        "G",
-        "H",
-        "I",
-        "J",
-        "K",
-        "L",
-        "M",
-        "N",
-        "O",
-        "P",
-    };
+        "A", "B", "C", "D", "E", "F", "G", "H", "I",
+        "J", "K", "L", "M", "N", "O", "P", "Q", "R"};
     static constexpr size_t kMaxBuckets = ARRAY_SIZE(kBucketNames);
 
     struct BucketState final {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -120,7 +120,7 @@ auto main(int argc, char **argv) -> int
 {
     using namespace calicodb;
     using namespace calicodb::test;
-    ::testing::InitGoogleTest(&argc, argv);
+    testing::InitGoogleTest(&argc, argv);
     default_env().srand(42);
 
 #define STR(name) #name
@@ -140,7 +140,7 @@ auto main(int argc, char **argv) -> int
     TEST_LOG << "Running \"" << argv[0] << "\"...\n";
 
     int rc = 0;
-    auto s = configure(kSetAllocator, DebugAllocator::config());
+    auto s = configure(kReplaceAllocator, DebugAllocator::config());
     if (!s.is_ok()) {
         TEST_LOG << "failed to set debug allocator: " << s.message() << '\n';
         REPORT_DRIVER_ERROR;

--- a/test/test_env.cpp
+++ b/test/test_env.cpp
@@ -143,7 +143,7 @@ static auto write_out_randomly(RandomGenerator &random, File &writer, const Slic
 
 struct EnvWithFiles final {
     explicit EnvWithFiles()
-        : m_dirname(testing::TempDir())
+        : m_dirname(testing::TempDir() + "calicodb_env_test")
     {
     }
 
@@ -326,7 +326,7 @@ TEST_P(FileTests, UseUnlinkedFile)
 INSTANTIATE_TEST_SUITE_P(
     FileTests,
     FileTests,
-    ::testing::Values(1, 2, 5, 10, 100));
+    testing::Values(1, 2, 5, 10, 100));
 
 class LoggerTests : public testing::Test
 {
@@ -335,7 +335,7 @@ protected:
         "0000/00/00-00:00:00.000000 ");
 
     explicit LoggerTests()
-        : m_log_filename(get_full_filename(testing::TempDir() + "logger"))
+        : m_log_filename(get_full_filename(testing::TempDir() + "calicodb_test_logger"))
     {
     }
 
@@ -537,7 +537,7 @@ TEST_P(EnvLockStateTests, InvalidRequestDeathTest)
 INSTANTIATE_TEST_SUITE_P(
     EnvLockStateTests,
     EnvLockStateTests,
-    ::testing::Values(1, 2, 5, 10, 100));
+    testing::Values(1, 2, 5, 10, 100));
 
 class EnvShmTests : public testing::Test
 {
@@ -942,7 +942,7 @@ TEST_P(FileConcurrencyTests, Run)
 INSTANTIATE_TEST_SUITE_P(
     FileConcurrencyTests,
     FileConcurrencyTests,
-    ::testing::Combine(
+    testing::Combine(
         testing::Values(1, 2, 5, 10),
         testing::Values(0, 1, 2, 5, 10)));
 
@@ -1168,7 +1168,7 @@ TEST_P(ShmConcurrencyTests, Run)
 INSTANTIATE_TEST_SUITE_P(
     SingleLock,
     ShmConcurrencyTests,
-    ::testing::Values(                            // 01234567
+    testing::Values(                              // 01234567
         std::vector<ShmLockPattern>{{0, 1, 1}},   // w.......
         std::vector<ShmLockPattern>{{0, 1, 0},    // r.......
                                     {0, 1, 1}},   // w.......
@@ -1184,7 +1184,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     MultiLock,
     ShmConcurrencyTests,
-    ::testing::Values(                            // 01234567
+    testing::Values(                              // 01234567
         std::vector<ShmLockPattern>{{0, 2, 1}},   // ww......
         std::vector<ShmLockPattern>{{0, 1, 0},    // r.......
                                     {0, 2, 1}},   // ww......

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -630,7 +630,7 @@ TEST_P(TreeSanityChecks, SmallRecords)
 INSTANTIATE_TEST_SUITE_P(
     TreeSanityChecks,
     TreeSanityChecks,
-    ::testing::Values(
+    testing::Values(
         0b00,
         0b01,
         0b10,
@@ -688,12 +688,12 @@ TEST_P(RemoteComparisonTests, Comparisons)
 INSTANTIATE_TEST_SUITE_P(
     SmallerThanPage,
     RemoteComparisonTests,
-    ::testing::Range(1U, TEST_PAGE_SIZE, 16));
+    testing::Range(1U, TEST_PAGE_SIZE, 16));
 
 INSTANTIATE_TEST_SUITE_P(
     LargerThanPage,
     RemoteComparisonTests,
-    ::testing::Range(TEST_PAGE_SIZE / 2, TEST_PAGE_SIZE * 2, 32));
+    testing::Range(TEST_PAGE_SIZE / 2, TEST_PAGE_SIZE * 2, 32));
 
 class EmptyTreeCursorTests : public TreeTests
 {
@@ -952,7 +952,7 @@ TEST_P(CursorTests, InvalidCursorDeathTest)
 INSTANTIATE_TEST_SUITE_P(
     CursorTests,
     CursorTests,
-    ::testing::Values(0, 1));
+    testing::Values(0, 1));
 
 class MultiCursorTests : public TreeTests
 {
@@ -1931,7 +1931,7 @@ TEST_P(RebalanceTests, E)
 INSTANTIATE_TEST_SUITE_P(
     RebalanceTests,
     RebalanceTests,
-    ::testing::Values(1, 2, 5));
+    testing::Values(1, 2, 5));
 
 TEST(SuffixTruncationTests, SuffixTruncation)
 {


### PR DESCRIPTION
Add options for changing system calls to calicodb::configure(). Add tests for system call failures to test_crashes.cpp. Modify the multiprocess concurrency tests. Run each test for 5 seconds, rather than a set number of iterations.